### PR TITLE
Secondary tags listing

### DIFF
--- a/partials/content.hbs
+++ b/partials/content.hbs
@@ -18,7 +18,6 @@
                     </span>
                 {{/primary_tag}}
                 <div>
-                
                     {{#foreach tags}}
                         {{#if @first}}
                         {{else}}

--- a/partials/content.hbs
+++ b/partials/content.hbs
@@ -17,15 +17,24 @@
                         </a>
                     </span>
                 {{/primary_tag}}
-                <div>
-                    <span class="tag-list-label">More:</span>
-                    {{#foreach tags}}
-                        {{#if @first}}
+                {{#has tag="count:>1"}}
+                    <div>
+                        <span class="tag-list-label">More:</span>
+                        {{#if primary_tag}}
+                            {{#foreach tags}}
+                                {{#if @first}}
+                                {{else}}
+                                    <a class="tag-list-item font-semibold" href="{{url}}">{{name}}</a>
+                                {{/if}}
+                            {{/foreach}}
                         {{else}}
-                            <a class="tag-list-item font-semibold" href="{{url}}">{{name}}</a>
+                            {{#foreach tags}}
+                                <a class="tag-list-item font-semibold" href="{{url}}">{{name}}</a>
+                            {{/foreach}}
                         {{/if}}
-                    {{/foreach}}
-                </div>
+                        
+                    </div>
+                {{/has}}
             </div>
         {{/is}}
         <h1 class="single-title">{{title}}</h1>

--- a/partials/content.hbs
+++ b/partials/content.hbs
@@ -17,6 +17,17 @@
                         </a>
                     </span>
                 {{/primary_tag}}
+                <div>
+                
+                    {{#foreach tags}}
+                        {{#if @first}}
+                        {{else}}
+                            <span class="single-meta-item">
+                                <a href="{{url}}">{{name}}</a>
+                            </span>
+                        {{/if}}
+                    {{/foreach}}
+                </div>
             </div>
         {{/is}}
         <h1 class="single-title">{{title}}</h1>

--- a/partials/content.hbs
+++ b/partials/content.hbs
@@ -18,12 +18,11 @@
                     </span>
                 {{/primary_tag}}
                 <div>
+                    <span class="tag-list-label">More:</span>
                     {{#foreach tags}}
                         {{#if @first}}
                         {{else}}
-                            <span class="single-meta-item">
-                                <a href="{{url}}">{{name}}</a>
-                            </span>
+                            <a class="tag-list-item font-semibold" href="{{url}}">{{name}}</a>
                         {{/if}}
                     {{/foreach}}
                 </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18213722/142900804-ea038323-cb64-44ab-b623-59f0f6f6e3e4.png)

I tried making a list of the secondary tags right below the primary tag, above the title. I believe this way makes more sense compared to putting the tags at the bottom of the article so that the reader can get an idea of what to expect in the article