### PR TITLE
TOC applies to H1 headings, while H2 headings are indented

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -231,10 +231,10 @@ function toc() {
         var toggle = $('.sticky-toc-button');
 
         $('.single-content')
-            .find('> h2, > h3')
+            .find('> h1, > h2')
             .each(function (index, value) {
                 var linkClass =
-                    $(this).prop('tagName') == 'H3'
+                    $(this).prop('tagName') == 'H2'
                         ? 'sticky-toc-link sticky-toc-link-indented'
                         : 'sticky-toc-link';
                 output +=

--- a/partials/header.hbs
+++ b/partials/header.hbs
@@ -50,7 +50,7 @@
                 <svg class="icon">
                     <use xlink:href="#table-of-contents"></use>
                 </svg>
-                <div class="sticky-toc"></div>
+                <div class="sticky-toc" style="overflow-y:auto; max-height:50vh"></div>
             </button>
             <div class="sticky-track">
                 <div class="sticky-progress"></div>

--- a/partials/header.hbs
+++ b/partials/header.hbs
@@ -50,7 +50,7 @@
                 <svg class="icon">
                     <use xlink:href="#table-of-contents"></use>
                 </svg>
-                <div class="sticky-toc" style="overflow-y:auto; max-height:50vh"></div>
+                <div class="sticky-toc" style="overflow-y: auto; max-height: 50vh"></div>
             </button>
             <div class="sticky-track">
                 <div class="sticky-progress"></div>


### PR DESCRIPTION
Before the commit

![image](https://user-images.githubusercontent.com/18213722/145322413-4ca8acf0-9542-4629-b4fb-dd37451f8f57.png)

After the Commit

![image](https://user-images.githubusercontent.com/18213722/145322479-a8c3b795-3e2b-4424-aa60-d7b2e4a97dc8.png)

![image](https://user-images.githubusercontent.com/18213722/145322523-a74643dd-f029-4980-932e-2825caa0b8fe.png)

I personally feel that the TOC may be too cluttered, so we could restrict the amount of text for each section? (put a ...) Or at least make it scrollable like documented in the other issue