### PR TITLE
fix: [#27] Optimize h1 font size in utils.css

### DIFF
--- a/assets/css/misc/utils.css
+++ b/assets/css/misc/utils.css
@@ -30,12 +30,12 @@
 }
 
 .u-text-format h1 {
-    font-size: 2.8rem;
+    font-size: 2.3rem;
     letter-spacing: -0.03rem;
 }
 
 .u-text-format h2 {
-    font-size: 2.3rem;
+    font-size: 2.2rem;
     letter-spacing: -0.03rem;
 }
 


### PR DESCRIPTION
- Current h1 font size is too large
- As such, I reduced the h1 font size from 2.8rem to 2.3rem.
- Also updated the h2 font size so that it will not clash with the new h1 font size.

![image](https://user-images.githubusercontent.com/69782911/157078178-4335149e-356f-48d7-95e3-c23efe31a74f.png)
