### PR TITLE
#79: Make industries shown on index and tags page consistent. 

### DIFF
--- a/assets/css/misc/utils.css
+++ b/assets/css/misc/utils.css
@@ -30,12 +30,12 @@
 }
 
 .u-text-format h1 {
-    font-size: 2.8rem;
+    font-size: 2.3rem;
     letter-spacing: -0.03rem;
 }
 
 .u-text-format h2 {
-    font-size: 2.3rem;
+    font-size: 2.2rem;
     letter-spacing: -0.03rem;
 }
 

--- a/index.hbs
+++ b/index.hbs
@@ -4,7 +4,7 @@
     <main class="site-main">
         <section class="tag">
             <div class="container medium">
-                {{#get "tags"}}
+                {{#get "tags" limit="all" as |tags|}}
                     {{#if tags}}
                         <div class="tag-list">
                             <span class="tag-list-label">Industries:</span>


### PR DESCRIPTION
Was unable to replicate the issue where the full list of industries is not shown. 

Instead, I fixed the inconsistency in the list of industries showed on the index page and the tags page as shown below.


Index: 
![image](https://user-images.githubusercontent.com/69782911/167558093-e93af280-1270-48f3-bd9e-945421193218.png)

Tags:
![image](https://user-images.githubusercontent.com/69782911/167558107-13ae5183-bdad-4da8-bce5-6a7367e1ceb2.png)
