### PR TITLE
[#60]: Add hover effects for post cards

### DIFF
--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -1,4 +1,4 @@
-<article class="feed-card {{post_class}} rounded-lg ring-1 ring-gray-900/5 shadow-xl">
+<article class="feed-card {{post_class}} rounded-lg ring-1 ring-gray-900/5 shadow-xl hover:shadow-md hover:border-opacity-0 transform hover:-translate-y-1 transition-all duration-200">
     <div onclick="location.href='{{url}}'" class="flex flex-col cursor-pointer h-full rounded-xl overflow-hidden md:flex-row md:h-60 lg:flex-col lg:h-full ">
         {{#if feature_image}}
         <img class="object-cover m-0 w-full h-60 md:min-w-[40%] md:max-w-[40%] md:h-full lg:w-full lg:max-w-full lg:h-60" src="{{img_url feature_image}}" alt="{{title}}" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,7 +10,9 @@ module.exports = {
         extend: {},
     },
     variants: {
-        extend: {},
+        extend: {
+            padding: ["hover"],
+        },
     },
     plugins: [require("@tailwindcss/line-clamp")],
 };


### PR DESCRIPTION
Added a simple shadow & translation effect upon hovering over the card, as shown in the screenshot below. 
![photo_2022-05-16_18-06-50 (2)](https://user-images.githubusercontent.com/69782911/168569956-ca0e9c3a-4326-494d-92fc-baaf197d98b5.jpg)
