### PR TITLE
Fix featured post slider URL positioning

### DIFF
--- a/partials/featured.hbs
+++ b/partials/featured.hbs
@@ -20,7 +20,7 @@
                 <div class="glide__track" data-glide-el="track">
                     <div class="glide__slides">
                         {{#foreach featured}}
-                            <article class="{{post_class}} glide__slide">
+                            <article class="{{post_class}} relative glide__slide">
                                 {{#if feature_image}}
                                     <div class="u-placeholder horizontal">
                                         <img class="lazyload u-object-fit"


### PR DESCRIPTION
This PR fixes a bug with the featured post slider on the homepage.

Currently, clicking on any featured post on the slider goes to the same URL which directs to a specific featured post. This is usually not the intended behaviour.
![2022-06-01_21h49_45](https://user-images.githubusercontent.com/52738067/171421395-de665135-817e-46b4-8196-2d3b5a3fe022.png)
(Observe that the URL destination shown in the bottom-left corner does not match the post shown)

This was due to erroneous usage of the `top: 0`, `bottom: 0` etc. positionings on the `<a>` tags. As the parent element `<article>` did not have a `position` attribute, the positioning of the `<a>` tags caused unintended behaviour. This PR fixes this bug by adding `position: relative` to the articles.
