### PR TITLE
fix large empty space

### DIFF
--- a/assets/css/blog/tag.css
+++ b/assets/css/blog/tag.css
@@ -31,11 +31,11 @@
     color: var(--brand-color);
 }
 
-.tag-media {
+.tag-feature-media {
     margin-top: 4.5rem;
 }
 
-.tag-media::before {
+.tag-feature-media::before {
     padding-bottom: 35% !important;
 }
 
@@ -44,7 +44,7 @@
         margin-bottom: 2.5rem;
     }
 
-    .tag-media {
+    .tag-feature-media {
         margin-top: 3rem;
     }
 }

--- a/tag.hbs
+++ b/tag.hbs
@@ -24,7 +24,7 @@
                 </div>
                 {{#if feature_image}}
                     <div class="container">
-                        <div class="tag-media u-placeholder horizontal">
+                        <div class="tag-feature-media u-placeholder horizontal">
                             <img class="u-object-fit" srcset="{{> srcset}}" src="{{img_url feature_image size="l"}}" alt="{{name}}">
                         </div>
                     </div>


### PR DESCRIPTION
Mainly changed the name of `tag-media` to `tag-featured-media`, so that it doesn't conflict with the ghost tags

![image](https://user-images.githubusercontent.com/18213722/182599362-36669227-ad88-45c5-bf81-205ec7917632.png)

![image](https://user-images.githubusercontent.com/18213722/182599374-ef016e49-f5f5-4268-b7c8-815d2d18ecff.png)

