### PR TITLE
Increase nav arrow size

### DIFF
--- a/assets/css/blog/navigation.css
+++ b/assets/css/blog/navigation.css
@@ -16,3 +16,19 @@
     width: 30px;
     height: 30px;
 }
+
+.navigation .navigation-icon {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+}
+
+.navigation{
+    position: relative;
+    height: 0;
+    width: 43px;
+    padding: 0;
+    padding-bottom: 43px;
+}


### PR DESCRIPTION
Had to use some CSS trickery to get the arrows larger than 30px. 
Tbh not too sure what everything does but the width and padding-bottom of the container scales the arrows.

referenced: https://css-tricks.com/scale-svg/

![Screenshot 2023-03-29 001659](https://user-images.githubusercontent.com/29113994/228304111-739c3499-20a4-4f1e-9266-bbea60dfd3f1.png)
