### PR TITLE
Icons on social media button not spaced consistently

### DIFF
--- a/assets/css/blog/share.css
+++ b/assets/css/blog/share.css
@@ -23,7 +23,6 @@
 }
 
 .share-link .icon-facebook {
-    margin-right: 0.3rem;
     margin-left: -0.3rem;
 }
 


### PR DESCRIPTION
Fixed the spacing between the "f" and "share".
Turns out it's just some extra right padding that can be removed. The SVG was not edited.
![new ss](https://user-images.githubusercontent.com/29113994/230712821-e2f00381-fb48-4ec6-9833-5d4c9afe93f9.png)


