### PR TITLE
[GPT-59] & [GPT-61]:  Change styling of tags

### DIFF
--- a/assets/css/blog/featured.css
+++ b/assets/css/blog/featured.css
@@ -42,3 +42,23 @@
     margin-top: 20px;
     margin-left: 20px;
 }
+
+@media (max-width: 767px) {
+    .flex.items-center {
+        display: block;
+        text-align: center;
+        justify-content: center;
+    }
+
+    .flex.items-center > span {
+        max-width: calc(50% - 0.75rem);
+        display: inline-block;
+        margin-right: 0.5rem;
+        margin-bottom: 0.5rem;
+    }
+
+    .flex.items-center > span:nth-child(3) {
+        max-width: 100%;
+        margin-right: 0;
+    }
+}

--- a/partials/featured.hbs
+++ b/partials/featured.hbs
@@ -29,7 +29,7 @@
                                         </div>
                                     {{/if}}
                                     <div class="slide-details">
-                                        <div class="flex items-center justify-center">
+                                        <div class="flex items-center" style="justify-content: {{#has number="2,3,4,8,11"}}flex-start{{else}}center{{/has}}">
                                             {{#foreach tags from="1"}}
                                                 <span class="text-xl inline-flex items-center font-bold 
                                                             leading-sm px-4 py-2 my-1 rounded-full 
@@ -49,7 +49,6 @@
                     </div>
                 </div>
             </div>
-            
         </section>
     {{/if}}
 {{/get}}

--- a/partials/featured.hbs
+++ b/partials/featured.hbs
@@ -29,13 +29,14 @@
                                         </div>
                                     {{/if}}
                                     <div class="slide-details">
-                                        <div>
+                                        <div class="flex items-center justify-center">
                                             {{#foreach tags from="1"}}
-                                            <span class="text-xl inline-flex items-center font-bold 
-                                                                            leading-sm px-4 py-2 my-1 rounded-full 
-                                                                            bg-brand-light text-gray-800 tag-element">
-                                                <a class="post-tag post-tag-{{slug}}" href="{{url}}">{{name}}</a>
-                                            </span>
+                                                <span class="text-xl inline-flex items-center font-bold 
+                                                            leading-sm px-4 py-2 my-1 rounded-full 
+                                                            bg-brand-light text-gray-800 tag-element text-center 
+                                                            {{#unless @last}}mr-2{{/unless}}">
+                                                    <a class="post-tag post-tag-{{slug}}" href="{{url}}">{{name}}</a>
+                                                </span>
                                             {{/foreach}}
                                         </div>
                                         <h3 class="post-title">{{title}}</h3>

--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -1,4 +1,4 @@
-<article class="feed-card {{post_class}} rounded-lg ring-1 ring-gray-900/5 shadow-xl m-auto w-full max-w-2xl md:max-w-full lg:h-full hover:shadow-md hover:border-opacity-0 transform hover:-translate-y-1 transition-all duration-200">
+<article class="feed-card {{post_class}} rounded-lg ring-1 shadow-xl m-auto w-full max-w-2xl md:max-w-full lg:h-full hover:shadow-md hover:border-opacity-0 transform hover:-translate-y-1 transition-all duration-200" style="--tw-ring-color: #808080">
     <div onclick="location.href='{{url}}'" class="flex flex-col cursor-pointer h-full rounded-xl overflow-hidden md:flex-row md:h-80 lg:flex-col lg:h-full">
         {{#if feature_image}}
         <img class="object-cover m-0 h-full md:aspect-[9/5] lg:h-auto lg:aspect-[15/8]" src="{{img_url feature_image}}" alt="{{title}}" />

--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -1,4 +1,4 @@
-<article class="feed-card {{post_class}} rounded-lg ring-1 shadow-xl m-auto w-full max-w-2xl md:max-w-full lg:h-full hover:shadow-md hover:border-opacity-0 transform hover:-translate-y-1 transition-all duration-200" style="--tw-ring-color: #808080">
+<article class="feed-card {{post_class}} rounded-lg ring-1 ring-gray-900/5 shadow-xl m-auto w-full max-w-2xl md:max-w-full lg:h-full hover:shadow-md hover:border-opacity-0 transform hover:-translate-y-1 transition-all duration-200">
     <div onclick="location.href='{{url}}'" class="flex flex-col cursor-pointer h-full rounded-xl overflow-hidden md:flex-row md:h-80 lg:flex-col lg:h-full">
         {{#if feature_image}}
         <img class="object-cover m-0 h-full md:aspect-[9/5] lg:h-auto lg:aspect-[15/8]" src="{{img_url feature_image}}" alt="{{title}}" />


### PR DESCRIPTION
Centered the tags on the featured articles

![image](https://github.com/AdvisorySG/dawn-advisory-theme/assets/73103636/72793e2a-3005-4115-999d-2479cd164d17)
