### PR TITLE
[GPT-89] Remove progress bar

### DIFF
--- a/assets/css/site/sticky.css
+++ b/assets/css/site/sticky.css
@@ -32,7 +32,7 @@
     left: 0;
     width: 100%;
     height: 2px;
-    background-color: var(--light-gray-color);
+    background-color: var(--brand-color);
 }
 
 .sticky-progress {

--- a/partials/content.hbs
+++ b/partials/content.hbs
@@ -57,7 +57,7 @@
         {{content}}
     </div>
     {{#is "post"}}
-        <footer class="single-footer container medium">
+        <div class="single-footer container medium">
             <div class="single-footer-left">
                 {{#prev_post}}
                     <div class="navigation navigation-previous">
@@ -106,6 +106,6 @@
                     </div>
                 {{/next_post}}
             </div>
-        </footer>
+        </div>
     {{/is}}
 </article>

--- a/partials/header.hbs
+++ b/partials/header.hbs
@@ -40,9 +40,7 @@
     {{#post}}
         <header class="sticky">
             <div class="sticky-title">{{title}}</div>
-            <div class="sticky-track">
-                <div class="sticky-progress"></div>
-            </div>
+            <div class="sticky-track" />
         </header>
     {{/post}}
 {{/is}}


### PR DESCRIPTION
![image](https://github.com/AdvisorySG/dawn-advisory-theme/assets/131253731/10dd145c-f24d-4b3c-b2e5-0da1a5edf7b5)
Replaced progress bar with a solid line of brand color