### PR TITLE
[GPT-119] Events & Interviews: Tag filter should apply to only articles of the respective types

### DIFF
--- a/assets/css/blog/tag.css
+++ b/assets/css/blog/tag.css
@@ -31,3 +31,7 @@
         margin-top: 3rem;
     }
 }
+
+.tag-content {
+    visibility: hidden;
+}

--- a/assets/css/blog/tag.css
+++ b/assets/css/blog/tag.css
@@ -31,7 +31,3 @@
         margin-top: 3rem;
     }
 }
-
-.tag-content {
-    visibility: hidden;
-}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -34,6 +34,7 @@ $(function () {
     burger();
     colourTags();
     contentDropdown();
+    tagContentFilter();
 });
 
 $(window).on('scroll', function () {
@@ -655,4 +656,31 @@ function contentDropdown() {
             });
         }
     });
+}
+
+function tagContentFilter() {
+    const context = new URLSearchParams(window.location.search).get('context');
+    const tagContent = document.querySelector('.tag-content');
+
+    if (!tagContent) {
+        console.log('No content to filter');
+        return;
+    }
+
+    const posts = tagContent.querySelectorAll('.post');
+    posts.forEach((post) => {
+        const postTags = post.getAttribute('class').split(' ');
+        if (context === 'events' && !postTags.includes('tag-hash-insights')) {
+            post.style.display = 'none';
+        } else if (
+            context === 'interviews' &&
+            !postTags.includes('tag-hash-conversations') &&
+            !postTags.includes('tag-hash-reflections')
+        ) {
+            post.style.display = 'none';
+        }
+    });
+
+    //Only reveals content after filtering is done
+    tagContent.style.visibility = 'visible';
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -663,7 +663,6 @@ function tagContentFilter() {
     const tagContent = document.querySelector('.tag-content');
 
     if (!tagContent) {
-        console.log('No content to filter');
         return;
     }
 
@@ -680,7 +679,4 @@ function tagContentFilter() {
             post.style.display = 'none';
         }
     });
-
-    //Only reveals content after filtering is done
-    tagContent.style.visibility = 'visible';
 }

--- a/events.hbs
+++ b/events.hbs
@@ -7,7 +7,7 @@
         <header class="single-header kg-canvas">
             <h1 class="single-title">Events</h1>
         </header>
-        {{> tags-listing }}
+        {{> tags-listing context = "events"}}
         <div class="post-feed container grid grid-cols-1 lg:grid-cols-3 gap-x-20 gap-y-10 m-auto">
             {{#foreach posts}}
                 {{> "post-card"}}

--- a/events.hbs
+++ b/events.hbs
@@ -7,7 +7,7 @@
         <header class="single-header kg-canvas">
             <h1 class="single-title">Events</h1>
         </header>
-        {{> tags-listing context = "events"}}
+        {{> tags-listing context="events"}}
         <div class="post-feed container grid grid-cols-1 lg:grid-cols-3 gap-x-20 gap-y-10 m-auto">
             {{#foreach posts}}
                 {{> "post-card"}}

--- a/index.hbs
+++ b/index.hbs
@@ -7,7 +7,7 @@
         <header class="single-header kg-canvas">
             <h1 class="single-title">Interviews</h1>
         </header>
-        {{> tags-listing }}
+        {{> tags-listing context="interviews"}}
         <div class="post-feed container grid grid-cols-1 lg:grid-cols-3 gap-x-20 gap-y-10 m-auto">
             {{#foreach posts}}
                 {{> "post-card"}}

--- a/partials/tags-listing.hbs
+++ b/partials/tags-listing.hbs
@@ -16,7 +16,7 @@
             {{#get "tags" limit="all" as |tags|}}
                 {{#if tags}}
                     {{#foreach tags}}
-                        <a href="{{url}}" class="block px-4 py-2 text-xl text-left text-gray-700 hover:bg-gray-100">{{name}}</a>
+                        <a href="{{url}}?context={{../../context}}" class="block px-4 py-2 text-xl text-left text-gray-700 hover:bg-gray-100">{{name}}</a>
                     {{/foreach}}
                 {{/if}}
             {{/get}}

--- a/tag.hbs
+++ b/tag.hbs
@@ -21,7 +21,7 @@
                 {{/if}}
             </section>
         {{/tag}}
-        <div class="post-feed container grid grid-cols-1 lg:grid-cols-3 gap-x-20 gap-y-10 m-auto">
+        <div class="tag-content post-feed container grid grid-cols-1 lg:grid-cols-3 gap-x-20 gap-y-10 m-auto">
             {{#foreach posts}}
                 {{> "post-card"}}
             {{/foreach}}


### PR DESCRIPTION
Now only shows insights when coming from the events page and conversations/reflections when coming from the interviews page. Closes #384 

![image](https://github.com/user-attachments/assets/5a1ee062-266f-472b-a43e-0fe16d5f7867)

