### PR TITLE
[GPT-132] dev: setup devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+# Node v20 setup - refer to below URL for details
+# https://github.com/nodesource/distributions?tab=readme-ov-file#using-ubuntu-nodejs-20
+RUN apt-get install -y curl \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh \
+    && bash nodesource_setup.sh \
+    && apt-get install -y nodejs \
+    && node -v  # verify Node installation
+
+# Ghost setup
+RUN npm install ghost-cli@latest -g
+USER vscode
+RUN mkdir ~/ghost \
+    && cd ~/ghost \
+    && ghost install local

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
     // Use 'postCreateCommand' to run commands after the container is created.
     "postCreateCommand": "$REPO/.devcontainer/ghost_setup.sh",
     "postStartCommand": "npm run prepare",
-    "postAttachCommand": "cd ~/ghost && ghost start"
+    "postAttachCommand": "cd ~/ghost && ghost start && cd $REPO && npm run dev"
 
     // Configure tool-specific properties.
     // "customizations": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+    "name": "Ubuntu 24.04 w/ Ghost",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "build": { "dockerfile": "Dockerfile" },
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "cd ~/ghost && ghost start"
+
+    // Configure tool-specific properties.
+    // "customizations": {},
+
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,8 +17,8 @@
 
     // Use 'postCreateCommand' to run commands after the container is created.
     "postCreateCommand": "$REPO/.devcontainer/ghost_setup.sh",
-
-    "postStartCommand": "cd ~/ghost && ghost start"
+    "postStartCommand": "npm run prepare",
+    "postAttachCommand": "cd ~/ghost && ghost start"
 
     // Configure tool-specific properties.
     // "customizations": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,8 +11,14 @@
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],
 
+    "containerEnv": {
+        "REPO": "/workspaces/dawn-advisory-theme"
+    },
+
     // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "cd ~/ghost && ghost start"
+    "postCreateCommand": "$REPO/.devcontainer/ghost_setup.sh",
+
+    "postStartCommand": "cd ~/ghost && ghost start"
 
     // Configure tool-specific properties.
     // "customizations": {},

--- a/.devcontainer/ghost_setup.sh
+++ b/.devcontainer/ghost_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+export REPO="/workspaces/dawn-advisory-theme"
+
+# Step 1: Create symbolic link to theme
+ln -s $REPO ~/ghost/content/themes
+
+# Step 2: Start Ghost
+cd ~/ghost
+ghost start
+
+# Step 3: Install dependencies + run setup script
+cd $REPO/.devcontainer/ghost_setup
+npm install && npm start

--- a/.devcontainer/ghost_setup/index.js
+++ b/.devcontainer/ghost_setup/index.js
@@ -1,0 +1,52 @@
+const readline = require("readline");
+const GhostAdminAPI = require("@tryghost/admin-api");
+
+const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    prompt: "> ",
+});
+
+console.log("---");
+console.log("Please do the following steps:");
+console.log("Step 1: Complete the setup at http://localhost:2368/ghost/.");
+console.log(
+    "The actual details don't matter, but make sure to save your username and password.",
+);
+console.log(
+    "Step 2: Follow https://ghost.org/docs/admin-api/#token-authentication to create an integration.",
+);
+console.log("Step 3: Copy the Admin API key into the following prompt.");
+console.log("---");
+
+(async () => {
+    const apiKey = await new Promise((callback) => {
+        rl.question("Admin API Key: ", callback);
+    });
+
+    const api = new GhostAdminAPI({
+        url: "http://localhost:2368",
+        version: "v5.0",
+        key: apiKey,
+    });
+
+    console.log("Activating repository theme...");
+    await api.themes.activate("dawn-advisory-theme").then((res) => {
+        console.log(JSON.stringify(res));
+    });
+    console.log("Finished setup!");
+
+    console.log("---");
+    console.log("The remaining steps need to be done manually:");
+    console.log(
+        "1. Under Settings > Advanced > Import/Export, import an export of the main Ghost website.",
+    );
+    console.log("2. Under Settings > Labs, import redirects and routes.");
+    console.log("For more details, please reach out to the maintainers! :)");
+    console.log("---");
+
+    await new Promise((callback) => {
+        rl.question("Press enter to continue...", callback);
+    });
+    rl.close();
+})();

--- a/.devcontainer/ghost_setup/package.json
+++ b/.devcontainer/ghost_setup/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "ghost_setup",
+    "version": "1.0.0",
+    "main": "index.js",
+    "scripts": {
+        "start": "node index.js"
+    },
+    "author": "",
+    "license": "MIT",
+    "description": "",
+    "dependencies": {
+        "@tryghost/admin-api": "^1.13.12"
+    }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     reviewers:
       - "AdvisorySG/ghost-reviewers"
     open-pull-requests-limit: 3
-    
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -21,7 +21,7 @@ updates:
     reviewers:
       - "AdvisorySG/ghost-reviewers"
     open-pull-requests-limit: 1
-    
+
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,9 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
 version: 2
 updates:
   - package-ecosystem: npm
@@ -7,3 +13,8 @@ updates:
     reviewers:
       - "AdvisorySG/ghost-reviewers"
     open-pull-requests-limit: 3
+  - package-ecosystem: devcontainers
+    directory: "/"
+    reviewers:
+      - "AdvisorySG/ghost-reviewers"
+    open-pull-requests-limit: 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
     open-pull-requests-limit: 3
   - package-ecosystem: devcontainers
     directory: "/"
+    schedule:
+      interval: weekly
     reviewers:
       - "AdvisorySG/ghost-reviewers"
     open-pull-requests-limit: 1

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     },
     "scripts": {
         "dev": "gulp",
-        "prepare": "husky install",
+        "prepare": "husky",
         "test": "gscan .",
         "test:ci": "gscan --fatal --verbose .",
         "zip": "gulp zip"


### PR DESCRIPTION
Closes https://github.com/AdvisorySG/dawn-advisory-theme/issues/410.

TODO:
- [x] Devcontainer using local development install
- [x] Symbolic link of repository to `content/themes/`
- [x] Change theme in Ghost admin
- ~~Import existing content from main website (this should ask for an API key)~~
- ~~Also import routes and redirects~~
- ~~Double check that there's no coupling with main website (i.e. any changes to devcontainer's version should not affect main website)~~