### PR TITLE
[GPT-166] build: upgrade to Ghost v6.5 w/ Node v22

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,11 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
-# Node v20 setup - refer to below URL for details
+# Node v22 setup - refer to below URL for details
 # https://github.com/nodesource/distributions?tab=readme-ov-file#using-ubuntu-nodejs-20
 RUN apt-get install -y curl \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x -o nodesource_setup.sh \
     && bash nodesource_setup.sh \
-    && apt-get install -y nodejs \
+    && apt-get install -y nodejs python3-setuptools \
     && node -v  # verify Node installation
 
 # Ghost setup

--- a/.devcontainer/ghost_setup/package.json
+++ b/.devcontainer/ghost_setup/package.json
@@ -9,6 +9,6 @@
     "license": "MIT",
     "description": "",
     "dependencies": {
-        "@tryghost/admin-api": "^1.13.12"
+        "@tryghost/admin-api": "^1.14.0"
     }
 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   pre_build:
     continue-on-error: true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v4
 
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,10 @@ on:
   push:
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v2
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
     "description": "Dawn theme for Ghost, adapted for Advisory SG.",
     "version": "1.0.0",
     "engines": {
-        "ghost": ">=5.0.0",
-        "node": "20.x"
+        "ghost": ">=6.5.0",
+        "node": "22.x"
     },
     "license": "MIT",
     "author": {
@@ -104,7 +104,7 @@
         "autoprefixer": "^10.4.18",
         "cssnano": "^7.0.5",
         "eslint": "^8.2.0",
-        "gscan": "^4.42.0",
+        "gscan": "^5.2.0",
         "gulp": "^4.0.2",
         "gulp-livereload": "^4.0.2",
         "gulp-postcss": "^10.0.0",


### PR DESCRIPTION
Closes https://github.com/AdvisorySG/dawn-advisory-theme/issues/464.