### PR TITLE
Remove warning message #462

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -20,13 +20,7 @@
 </style>
 <div class="content-area">
     <main class="site-main">
-        <div class="container pb-24">
-            <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
-                <strong class="font-bold">Disclaimer</strong>
-                <span class="block sm:inline">Posts before 31st March 2024 may be incomplete or contain errors. You can refer to <a href="https://old.advisory.sg">old.advisory.sg</a> for the original article.</span>
-            </div>
-        </div>
-
+        
     <div class="contentinfoarea">
         {{#post}}
             {{> content width="wide"}}
@@ -42,4 +36,5 @@
             {{> comment}}
         {{/is}}
     </main>
+
 </div>


### PR DESCRIPTION
Removed warning message "Disclaimer Posts before 31st March 2024 may be incomplete or contain errors. You can refer to [old.advisory.sg](https://old.advisory.sg/) for the original article."