### PR TITLE
[GPT-161] docs(specs): add sort/filter design for events and interviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm run zip
 For new developers, please ask Tech Management for the posts and settings to be exported, and to pass you the output JSON file.
 This file can be imported into your local instance of Ghost, at `Settings > Labs > Migration Options > Import content`. Take note that this will not remove existing posts/pages.
 
-Optionally, if you have access to the [Admin panel of Advisory](https://beta.advisory.sg/ghost/), you can go to `Settings > Labs > Migration Options > Export your content` in order to export the posts and settings used for the actual website as a JSON file. 
+Optionally, if you have access to the [Admin panel of Advisory](https://beta.advisory.sg/ghost/), you can go to `Settings > Labs > Migration Options > Export your content` in order to export the posts and settings used for the actual website as a JSON file.
 
 Furthermore, also make sure to setup `routes.yaml` as explained further down below
 
@@ -71,9 +71,27 @@ For the homepage and separate [Stories](https://beta.advisory.sg/stories) page t
 
 **Note**: The `routes.yaml` file supplied in the repository is not automatically deployed onto the main website.
 
+# Typesense Search
+
+The `/events/` and `/interviews/` pages have a typo-tolerant search box backed by [Typesense](https://typesense.org/). Three settings live under `config.custom` in `package.json` and are admin-overridable in **Ghost Admin → Settings → Design → Customize**:
+
+| Setting                | Default                         | What it is                                                         |
+| ---------------------- | ------------------------------- | ------------------------------------------------------------------ |
+| `typesense_host`       | `https://typesense.advisory.sg` | Typesense host URL (no trailing slash). HTTPS recommended.         |
+| `typesense_api_key`    | (Advisory SG search-only key)   | Typesense **search-only** API key. Embedded client-side by design. |
+| `typesense_collection` | `ghost`                         | Name of the indexed Ghost-posts collection on the Typesense host.  |
+
+The flow is: `package.json` defaults → `default.hbs` injects them as `window.__TYPESENSE_CONFIG__` → `assets/js/typesense-search.js` reads from that global at search time, falling back to the same defaults if the global is missing.
+
+**About the API key in source.** Typesense splits keys into _admin_ (read/write, secret) and _search-only_ (read-only, scoped to a collection). The search-only key is the analogue of Ghost's Content API key — it's designed to ship in client-side JavaScript and only grants read access to data that's already public. Don't paste an admin key here.
+
+**Deploying to a different Ghost instance.** If your instance points at a different Typesense backend, override the three settings in **Design → Customize** rather than editing the theme. The defaults in `package.json` are only the fallback for installs that don't override.
+
+**About the indexer.** This theme expects an existing Typesense collection populated with Ghost posts (`title`, `slug`, `excerpt`, `plaintext`, `tags.slug`, `published_at`, etc.). The sync mechanism (e.g. [MagicPages' Ghost-Typesense integration](https://github.com/magicpages/ghost-typesense)) is **not** part of this theme.
+
 # PostCSS Features Used
 
-- Autoprefixer - Don't worry about writing browser prefixes of any kind, it's all done automatically with support for the latest 2 major versions of every browser.
+-   Autoprefixer - Don't worry about writing browser prefixes of any kind, it's all done automatically with support for the latest 2 major versions of every browser.
 
 # Copyright & License
 

--- a/assets/css/misc/utils.css
+++ b/assets/css/misc/utils.css
@@ -155,3 +155,7 @@
     height: 100%;
     object-fit: cover;
 }
+
+[x-cloak] {
+    display: none !important;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -8,7 +8,10 @@ import Glide from '@glidejs/glide';
 import Alpine from 'alpinejs';
 import 'flowbite';
 
+import postFilterList from './post-filter-list.js';
+
 window.Alpine = Alpine;
+Alpine.data('postFilterList', postFilterList);
 Alpine.start();
 
 var body = $('body');

--- a/assets/js/post-filter-list.js
+++ b/assets/js/post-filter-list.js
@@ -1,29 +1,52 @@
-// Alpine component for client-side multi-tag filter, load-more, and URL sync.
+// Alpine component for client-side multi-tag filter, sort, search, load-more, and URL sync.
 // Used by partials/post-filter-list.hbs on /events/ and /interviews/.
 //
 // Call site:
-//   <div x-data="postFilterList({ collection: 'events', mode: 'or' })" ...>
+//   <div x-data="postFilterList({ collection: 'events', mode: 'or', tagSlugs: 'hash-insights,...' })" ...>
 //
 // Parameters:
 //   collection: passed through for the partial's DOM id namespace; not used here.
-//   mode: 'or' (default) or 'and'. Selects matching function.
-export default function postFilterList({ collection, mode }) {
+//   mode: 'or' (default) or 'and'. Selects matching function for chips.
+//   tagSlugs: comma-separated string of tag slugs scoping this collection (used by Task 7 for Typesense filter_by). Not consumed in Task 3.
+export default function postFilterList({ collection, mode, tagSlugs }) {
     const PAGE_SIZE = 12;
 
     return {
+        // --- state -------------------------------------------------------
         selectedTags: [],
+        sortMode: 'newest', // 'newest' | 'oldest' | 'az' | 'za'
         visibleCount: PAGE_SIZE,
         allCards: [],
         availableTags: [],
+        tagSlugs: (tagSlugs || '')
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean),
+
+        // --- lifecycle ---------------------------------------------------
 
         init() {
             this.allCards = this._readCardsFromDom();
             this.availableTags = this._buildAvailableTags(this.allCards);
-            this.selectedTags = this._readTagsFromUrl();
+
+            const state = this._readStateFromUrl();
+            this.selectedTags = state.tags;
+            this.sortMode = state.sort;
+
             this.$watch('selectedTags', () => {
                 this.visibleCount = PAGE_SIZE;
-                this._writeTagsToUrl();
+                this._writeStateToUrl();
             });
+            this.$watch('sortMode', () => {
+                this.visibleCount = PAGE_SIZE;
+                this._reorderDom();
+                this._writeStateToUrl();
+            });
+
+            // Apply initial DOM order if URL specified a non-default sort.
+            if (this.sortMode !== 'newest') {
+                this._reorderDom();
+            }
         },
 
         // --- queries -----------------------------------------------------
@@ -37,7 +60,9 @@ export default function postFilterList({ collection, mode }) {
         },
 
         filtered() {
-            return this.allCards.filter((c) => this.matches(c));
+            const tagFiltered = this.allCards.filter((c) => this.matches(c));
+            // Search filter (added in Task 7).
+            return this._sorted(tagFiltered);
         },
 
         visible() {
@@ -76,7 +101,6 @@ export default function postFilterList({ collection, mode }) {
         loadMore() {
             this.visibleCount += PAGE_SIZE;
             // Move focus to the first newly-revealed card for keyboard users.
-            // The wrapper element carries tabindex="-1" (set in the partial).
             this.$nextTick(() => {
                 const newIndex = this.visibleCount - PAGE_SIZE;
                 const card = this.filtered()[newIndex];
@@ -86,9 +110,46 @@ export default function postFilterList({ collection, mode }) {
 
         clearFilters() {
             this.selectedTags = [];
+            this.sortMode = 'newest';
+            // Search reset added in Task 7.
         },
 
         // --- internals ---------------------------------------------------
+
+        _sorted(cards) {
+            const sorted = [...cards];
+            switch (this.sortMode) {
+                case 'oldest':
+                    sorted.sort((a, b) =>
+                        a.publishedAt.localeCompare(b.publishedAt),
+                    );
+                    break;
+                case 'az':
+                    sorted.sort((a, b) => a.title.localeCompare(b.title));
+                    break;
+                case 'za':
+                    sorted.sort((a, b) => b.title.localeCompare(a.title));
+                    break;
+                case 'newest':
+                default:
+                    sorted.sort((a, b) =>
+                        b.publishedAt.localeCompare(a.publishedAt),
+                    );
+                    break;
+            }
+            return sorted;
+        },
+
+        // Reorders ALL .filter-card-wrapper nodes in the grid to match the current sort.
+        // Hidden cards (x-show=false) reorder along with visible ones; CSS Grid then
+        // lays out only the visible ones in their new DOM order.
+        _reorderDom() {
+            if (this.allCards.length === 0) return;
+            const grid = this.allCards[0].el.parentNode;
+            if (!grid) return;
+            const sorted = this._sorted(this.allCards);
+            sorted.forEach((c) => grid.appendChild(c.el));
+        },
 
         _readCardsFromDom() {
             const root = this.$root || this.$el;
@@ -101,7 +162,13 @@ export default function postFilterList({ collection, mode }) {
                     .split(',')
                     .map((s) => s.trim())
                     .filter(Boolean);
-                return { el, tagSlugs: new Set(slugs) };
+                return {
+                    el,
+                    tagSlugs: new Set(slugs),
+                    slug: (inner && inner.dataset.slug) || '',
+                    title: (inner && inner.dataset.title) || '',
+                    publishedAt: (inner && inner.dataset.publishedAt) || '',
+                };
             });
         },
 
@@ -125,22 +192,36 @@ export default function postFilterList({ collection, mode }) {
             );
         },
 
-        _readTagsFromUrl() {
+        _readStateFromUrl() {
             const params = new URLSearchParams(window.location.search);
-            const raw = params.get('tags') || '';
-            return raw
+
+            const tags = (params.get('tags') || '')
                 .split(',')
                 .map((s) => s.trim())
                 .filter(Boolean);
+
+            const rawSort = params.get('sort') || 'newest';
+            const validSorts = ['newest', 'oldest', 'az', 'za'];
+            const sort = validSorts.includes(rawSort) ? rawSort : 'newest';
+
+            return { tags, sort };
         },
 
-        _writeTagsToUrl() {
+        _writeStateToUrl() {
             const params = new URLSearchParams(window.location.search);
+
             if (this.selectedTags.length) {
                 params.set('tags', this.selectedTags.join(','));
             } else {
                 params.delete('tags');
             }
+
+            if (this.sortMode && this.sortMode !== 'newest') {
+                params.set('sort', this.sortMode);
+            } else {
+                params.delete('sort');
+            }
+
             const qs = params.toString();
             const newUrl = qs
                 ? `${window.location.pathname}?${qs}`

--- a/assets/js/post-filter-list.js
+++ b/assets/js/post-filter-list.js
@@ -8,7 +8,10 @@ import { searchSlugs } from './typesense-search.js';
 // Parameters:
 //   collection: passed through for the partial's DOM id namespace; not used here.
 //   mode: 'or' (default) or 'and'. Selects matching function for chips.
-//   tagSlugs: comma-separated string of tag slugs scoping this collection (used by Task 7 for Typesense filter_by). Not consumed in Task 3.
+//   tagSlugs: comma-separated string of tag slugs scoping this collection.
+//             Parsed into an array and passed to searchSlugs() as the
+//             Typesense filter_by value so cross-collection slug results
+//             don't bleed into this page.
 // Sort modes accepted in URL params and the dropdown UI.
 // Keep this list in sync with the <select> options in partials/post-filter-list.hbs
 // and the cases in _sorted() below.
@@ -44,7 +47,9 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
             const state = this._readStateFromUrl();
             this.selectedTags = state.tags;
             this.sortMode = state.sort;
-            this.searchQuery = state.q;
+            // Normalize sub-threshold queries to '' so the input doesn't
+            // display a stale character with no active search behind it.
+            this.searchQuery = state.q.trim().length >= 2 ? state.q : '';
 
             this.$watch('selectedTags', () => {
                 this.visibleCount = PAGE_SIZE;
@@ -104,6 +109,16 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
             return this.filtered().length > this.visibleCount;
         },
 
+        // True when any user-controlled dimension is non-default — drives
+        // the visibility of every Clear-filters affordance.
+        hasActiveFilters() {
+            return (
+                this.selectedTags.length > 0 ||
+                this.searchQuery.trim().length > 0 ||
+                this.sortMode !== 'newest'
+            );
+        },
+
         // --- actions -----------------------------------------------------
 
         isSelected(slug) {
@@ -131,6 +146,12 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
         setSearchQuery(value) {
             this.searchQuery = value;
             clearTimeout(this._searchDebounceTimer);
+            // Empty/short input goes through immediately so Esc-to-clear
+            // doesn't leave the URL ?q= and result count stale for 250ms.
+            if (value.trim().length < 2) {
+                this._runSearch();
+                return;
+            }
             this._searchDebounceTimer = setTimeout(() => {
                 this._runSearch();
             }, 250);

--- a/assets/js/post-filter-list.js
+++ b/assets/js/post-filter-list.js
@@ -23,6 +23,7 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
     return {
         // --- state -------------------------------------------------------
         selectedTags: [],
+        tagDropdownOpen: false,
         sortMode: 'newest', // 'newest' | 'oldest' | 'az' | 'za'
         visibleCount: PAGE_SIZE,
         allCards: [],
@@ -131,6 +132,24 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
             } else {
                 this.selectedTags = [...this.selectedTags, slug];
             }
+        },
+
+        selectedTagLabel() {
+            return this.selectedTags.length
+                ? `Tags (${this.selectedTags.length})`
+                : 'Tags';
+        },
+
+        clearTags() {
+            this.selectedTags = [];
+        },
+
+        toggleTagDropdown() {
+            this.tagDropdownOpen = !this.tagDropdownOpen;
+        },
+
+        closeTagDropdown() {
+            this.tagDropdownOpen = false;
         },
 
         loadMore() {

--- a/assets/js/post-filter-list.js
+++ b/assets/js/post-filter-list.js
@@ -1,3 +1,4 @@
+import { searchSlugs } from './typesense-search.js';
 // Alpine component for client-side multi-tag filter, sort, search, load-more, and URL sync.
 // Used by partials/post-filter-list.hbs on /events/ and /interviews/.
 //
@@ -27,6 +28,12 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
             .split(',')
             .map((s) => s.trim())
             .filter(Boolean),
+        searchQuery: '',
+        searchSlugs: null, // null = no search active or query < 2 chars; Set = Typesense results
+        searchError: false,
+        isSearching: false,
+        _searchAbortController: null,
+        _searchDebounceTimer: null,
 
         // --- lifecycle ---------------------------------------------------
 
@@ -37,6 +44,7 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
             const state = this._readStateFromUrl();
             this.selectedTags = state.tags;
             this.sortMode = state.sort;
+            this.searchQuery = state.q;
 
             this.$watch('selectedTags', () => {
                 this.visibleCount = PAGE_SIZE;
@@ -52,6 +60,11 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
             if (this.sortMode !== 'newest') {
                 this._reorderDom();
             }
+
+            // Fire a search if URL had ?q=… on load.
+            if (this.searchQuery.trim().length >= 2) {
+                this._runSearch();
+            }
         },
 
         // --- queries -----------------------------------------------------
@@ -65,9 +78,11 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
         },
 
         filtered() {
-            const tagFiltered = this.allCards.filter((c) => this.matches(c));
-            // Search filter (added in Task 7).
-            return this._sorted(tagFiltered);
+            let result = this.allCards.filter((c) => this.matches(c));
+            if (this.searchSlugs !== null) {
+                result = result.filter((c) => this.searchSlugs.has(c.slug));
+            }
+            return this._sorted(result);
         },
 
         visible() {
@@ -113,10 +128,20 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
             });
         },
 
+        setSearchQuery(value) {
+            this.searchQuery = value;
+            clearTimeout(this._searchDebounceTimer);
+            this._searchDebounceTimer = setTimeout(() => {
+                this._runSearch();
+            }, 250);
+        },
+
         clearFilters() {
             this.selectedTags = [];
             this.sortMode = 'newest';
-            // Search reset added in Task 7.
+            this.searchQuery = '';
+            this.searchSlugs = null;
+            this.searchError = false;
         },
 
         // --- internals ---------------------------------------------------
@@ -160,6 +185,46 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
             if (!grid) return;
             const sorted = this._sorted(this.allCards);
             sorted.forEach((c) => grid.appendChild(c.el));
+        },
+
+        async _runSearch() {
+            const trimmed = this.searchQuery.trim();
+
+            // Cancel any in-flight request — newer query supersedes it.
+            if (this._searchAbortController) {
+                this._searchAbortController.abort();
+            }
+
+            // Short-circuit: <2 chars means no search active.
+            if (trimmed.length < 2) {
+                this.searchSlugs = null;
+                this.searchError = false;
+                this.isSearching = false;
+                this.visibleCount = PAGE_SIZE;
+                this._writeStateToUrl();
+                return;
+            }
+
+            this._searchAbortController = new AbortController();
+            this.isSearching = true;
+
+            try {
+                const slugs = await searchSlugs(
+                    trimmed,
+                    this.tagSlugs,
+                    this._searchAbortController.signal,
+                );
+                this.searchSlugs = slugs;
+                this.searchError = false;
+                this.visibleCount = PAGE_SIZE;
+                this._writeStateToUrl();
+            } catch (err) {
+                if (err.name === 'AbortError') return; // newer query is in flight
+                this.searchSlugs = null;
+                this.searchError = true;
+            } finally {
+                this.isSearching = false;
+            }
         },
 
         _readCardsFromDom() {
@@ -214,7 +279,9 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
             const rawSort = params.get('sort') || 'newest';
             const sort = VALID_SORTS.includes(rawSort) ? rawSort : 'newest';
 
-            return { tags, sort };
+            const q = params.get('q') || '';
+
+            return { tags, sort, q };
         },
 
         _writeStateToUrl() {
@@ -230,6 +297,13 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
                 params.set('sort', this.sortMode);
             } else {
                 params.delete('sort');
+            }
+
+            const q = (this.searchQuery || '').trim();
+            if (q.length >= 2) {
+                params.set('q', q);
+            } else {
+                params.delete('q');
             }
 
             const qs = params.toString();

--- a/assets/js/post-filter-list.js
+++ b/assets/js/post-filter-list.js
@@ -1,0 +1,141 @@
+// Alpine component for client-side multi-tag filter, load-more, and URL sync.
+// Used by partials/post-filter-list.hbs on /events/ and /interviews/.
+//
+// Call site:
+//   <div x-data="postFilterList({ collection: 'events', mode: 'or' })" ...>
+export default function postFilterList({ collection, mode }) {
+    const PAGE_SIZE = 12;
+
+    return {
+        selectedTags: [],
+        visibleCount: PAGE_SIZE,
+        allCards: [],
+        availableTags: [],
+
+        init() {
+            this.allCards = this._readCardsFromDom();
+            this.availableTags = this._buildAvailableTags();
+            this.selectedTags = this._readTagsFromUrl();
+            this.$watch('selectedTags', () => {
+                this.visibleCount = PAGE_SIZE;
+                this._writeTagsToUrl();
+            });
+        },
+
+        // --- queries -----------------------------------------------------
+
+        matches(card) {
+            if (this.selectedTags.length === 0) return true;
+            if (mode === 'and') {
+                return this.selectedTags.every((t) => card.tagSlugs.has(t));
+            }
+            return this.selectedTags.some((t) => card.tagSlugs.has(t));
+        },
+
+        filtered() {
+            return this.allCards.filter((c) => this.matches(c));
+        },
+
+        visible() {
+            return this.filtered().slice(0, this.visibleCount);
+        },
+
+        isVisible(el) {
+            return this.visible().some((c) => c.el === el);
+        },
+
+        unknownTags() {
+            const known = new Set(this.availableTags.map((t) => t.slug));
+            return this.selectedTags.filter((s) => !known.has(s));
+        },
+
+        hasMore() {
+            return this.filtered().length > this.visibleCount;
+        },
+
+        // --- actions -----------------------------------------------------
+
+        isSelected(slug) {
+            return this.selectedTags.includes(slug);
+        },
+
+        toggleTag(slug) {
+            if (this.isSelected(slug)) {
+                this.selectedTags = this.selectedTags.filter((s) => s !== slug);
+            } else {
+                this.selectedTags = [...this.selectedTags, slug];
+            }
+        },
+
+        loadMore() {
+            this.visibleCount += PAGE_SIZE;
+            // Move focus to the first newly-revealed card for keyboard users.
+            this.$nextTick(() => {
+                const newIndex = this.visibleCount - PAGE_SIZE;
+                const card = this.filtered()[newIndex];
+                if (card && card.el) card.el.focus();
+            });
+        },
+
+        clearFilters() {
+            this.selectedTags = [];
+        },
+
+        // --- internals ---------------------------------------------------
+
+        _readCardsFromDom() {
+            const root = this.$root || this.$el;
+            const cards = root.querySelectorAll('[data-tags]');
+            return Array.from(cards).map((el) => {
+                const slugs = (el.dataset.tags || '')
+                    .split(',')
+                    .map((s) => s.trim())
+                    .filter(Boolean);
+                return { el, tagSlugs: new Set(slugs) };
+            });
+        },
+
+        _buildAvailableTags() {
+            const root = this.$root || this.$el;
+            const cards = root.querySelectorAll('[data-tags]');
+            const map = new Map();
+            cards.forEach((el) => {
+                const slugs = (el.dataset.tags || '').split(',');
+                const names = (el.dataset.tagNames || '').split('|');
+                slugs.forEach((slug, i) => {
+                    const s = slug.trim();
+                    if (!s) return;
+                    if (!map.has(s)) {
+                        map.set(s, { slug: s, name: (names[i] || s).trim() });
+                    }
+                });
+            });
+            return Array.from(map.values()).sort((a, b) =>
+                a.name.localeCompare(b.name),
+            );
+        },
+
+        _readTagsFromUrl() {
+            const params = new URLSearchParams(window.location.search);
+            const raw = params.get('tags') || '';
+            return raw
+                .split(',')
+                .map((s) => s.trim())
+                .filter(Boolean);
+        },
+
+        _writeTagsToUrl() {
+            const params = new URLSearchParams(window.location.search);
+            if (this.selectedTags.length) {
+                params.set('tags', this.selectedTags.join(','));
+            } else {
+                params.delete('tags');
+            }
+            const qs = params.toString();
+            const newUrl = qs
+                ? `${window.location.pathname}?${qs}`
+                : window.location.pathname;
+            window.history.replaceState(null, '', newUrl);
+        },
+    };
+}

--- a/assets/js/post-filter-list.js
+++ b/assets/js/post-filter-list.js
@@ -8,6 +8,11 @@
 //   collection: passed through for the partial's DOM id namespace; not used here.
 //   mode: 'or' (default) or 'and'. Selects matching function for chips.
 //   tagSlugs: comma-separated string of tag slugs scoping this collection (used by Task 7 for Typesense filter_by). Not consumed in Task 3.
+// Sort modes accepted in URL params and the dropdown UI.
+// Keep this list in sync with the <select> options in partials/post-filter-list.hbs
+// and the cases in _sorted() below.
+const VALID_SORTS = ['newest', 'oldest', 'az', 'za'];
+
 export default function postFilterList({ collection, mode, tagSlugs }) {
     const PAGE_SIZE = 12;
 
@@ -141,8 +146,14 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
         },
 
         // Reorders ALL .filter-card-wrapper nodes in the grid to match the current sort.
-        // Hidden cards (x-show=false) reorder along with visible ones; CSS Grid then
-        // lays out only the visible ones in their new DOM order.
+        // Hidden cards (x-show=false → display:none) reorder along with visible ones;
+        // CSS Grid skips display:none items in auto-flow, so the visible ones lay out
+        // in their new DOM order.
+        //
+        // Assumes every .filter-card-wrapper shares the same parent element (the
+        // #post-grid-{collection} div in post-filter-list.hbs). If a future partial
+        // change splits cards across multiple containers, this loop will silently
+        // re-parent them all to the first card's parent.
         _reorderDom() {
             if (this.allCards.length === 0) return;
             const grid = this.allCards[0].el.parentNode;
@@ -201,8 +212,7 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
                 .filter(Boolean);
 
             const rawSort = params.get('sort') || 'newest';
-            const validSorts = ['newest', 'oldest', 'az', 'za'];
-            const sort = validSorts.includes(rawSort) ? rawSort : 'newest';
+            const sort = VALID_SORTS.includes(rawSort) ? rawSort : 'newest';
 
             return { tags, sort };
         },

--- a/assets/js/post-filter-list.js
+++ b/assets/js/post-filter-list.js
@@ -3,6 +3,10 @@
 //
 // Call site:
 //   <div x-data="postFilterList({ collection: 'events', mode: 'or' })" ...>
+//
+// Parameters:
+//   collection: passed through for the partial's DOM id namespace; not used here.
+//   mode: 'or' (default) or 'and'. Selects matching function.
 export default function postFilterList({ collection, mode }) {
     const PAGE_SIZE = 12;
 
@@ -14,7 +18,7 @@ export default function postFilterList({ collection, mode }) {
 
         init() {
             this.allCards = this._readCardsFromDom();
-            this.availableTags = this._buildAvailableTags();
+            this.availableTags = this._buildAvailableTags(this.allCards);
             this.selectedTags = this._readTagsFromUrl();
             this.$watch('selectedTags', () => {
                 this.visibleCount = PAGE_SIZE;
@@ -40,6 +44,8 @@ export default function postFilterList({ collection, mode }) {
             return this.filtered().slice(0, this.visibleCount);
         },
 
+        // el must be the [data-tags] element itself (the same node stored in allCards),
+        // not a wrapper. The caller is responsible for passing the right node.
         isVisible(el) {
             return this.visible().some((c) => c.el === el);
         },
@@ -70,6 +76,8 @@ export default function postFilterList({ collection, mode }) {
         loadMore() {
             this.visibleCount += PAGE_SIZE;
             // Move focus to the first newly-revealed card for keyboard users.
+            // The card element (the one stored in allCards) must have tabindex="-1"
+            // applied in the template — otherwise focus() silently no-ops on <article>.
             this.$nextTick(() => {
                 const newIndex = this.visibleCount - PAGE_SIZE;
                 const card = this.filtered()[newIndex];
@@ -95,11 +103,9 @@ export default function postFilterList({ collection, mode }) {
             });
         },
 
-        _buildAvailableTags() {
-            const root = this.$root || this.$el;
-            const cards = root.querySelectorAll('[data-tags]');
+        _buildAvailableTags(cards) {
             const map = new Map();
-            cards.forEach((el) => {
+            cards.forEach(({ el }) => {
                 const slugs = (el.dataset.tags || '').split(',');
                 const names = (el.dataset.tagNames || '').split('|');
                 slugs.forEach((slug, i) => {

--- a/assets/js/post-filter-list.js
+++ b/assets/js/post-filter-list.js
@@ -140,8 +140,18 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
             this.selectedTags = [];
             this.sortMode = 'newest';
             this.searchQuery = '';
+            // Cancel any in-flight search and pending debounce so a stale
+            // response can't overwrite searchSlugs after the clear.
+            if (this._searchAbortController) {
+                this._searchAbortController.abort();
+            }
+            clearTimeout(this._searchDebounceTimer);
             this.searchSlugs = null;
             this.searchError = false;
+            this.isSearching = false;
+            // selectedTags/sortMode watchers fire only on change. Force a URL
+            // write so ?q= and ?sort= drop even when those weren't dirty.
+            this._writeStateToUrl();
         },
 
         // --- internals ---------------------------------------------------
@@ -205,14 +215,19 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
                 return;
             }
 
-            this._searchAbortController = new AbortController();
+            // Capture the controller locally so finally{} can tell whether
+            // THIS call is still the latest. Without this, an aborted call's
+            // finally{} flips isSearching=false while the superseding call is
+            // still in flight, making the spinner flicker off mid-typing.
+            const controller = new AbortController();
+            this._searchAbortController = controller;
             this.isSearching = true;
 
             try {
                 const slugs = await searchSlugs(
                     trimmed,
                     this.tagSlugs,
-                    this._searchAbortController.signal,
+                    controller.signal,
                 );
                 this.searchSlugs = slugs;
                 this.searchError = false;
@@ -223,7 +238,9 @@ export default function postFilterList({ collection, mode, tagSlugs }) {
                 this.searchSlugs = null;
                 this.searchError = true;
             } finally {
-                this.isSearching = false;
+                if (this._searchAbortController === controller) {
+                    this.isSearching = false;
+                }
             }
         },
 

--- a/assets/js/post-filter-list.js
+++ b/assets/js/post-filter-list.js
@@ -44,8 +44,8 @@ export default function postFilterList({ collection, mode }) {
             return this.filtered().slice(0, this.visibleCount);
         },
 
-        // el must be the [data-tags] element itself (the same node stored in allCards),
-        // not a wrapper. The caller is responsible for passing the right node.
+        // el must be the .filter-card-wrapper element (the same node stored in allCards).
+        // The wrapper carries tabindex="-1" so loadMore() can focus it.
         isVisible(el) {
             return this.visible().some((c) => c.el === el);
         },
@@ -76,8 +76,7 @@ export default function postFilterList({ collection, mode }) {
         loadMore() {
             this.visibleCount += PAGE_SIZE;
             // Move focus to the first newly-revealed card for keyboard users.
-            // The card element (the one stored in allCards) must have tabindex="-1"
-            // applied in the template — otherwise focus() silently no-ops on <article>.
+            // The wrapper element carries tabindex="-1" (set in the partial).
             this.$nextTick(() => {
                 const newIndex = this.visibleCount - PAGE_SIZE;
                 const card = this.filtered()[newIndex];
@@ -93,9 +92,12 @@ export default function postFilterList({ collection, mode }) {
 
         _readCardsFromDom() {
             const root = this.$root || this.$el;
-            const cards = root.querySelectorAll('[data-tags]');
-            return Array.from(cards).map((el) => {
-                const slugs = (el.dataset.tags || '')
+            const wrappers = root.querySelectorAll('.filter-card-wrapper');
+            return Array.from(wrappers).map((el) => {
+                const inner = el.querySelector('[data-tags]');
+                const slugs = (
+                    inner && inner.dataset.tags ? inner.dataset.tags : ''
+                )
                     .split(',')
                     .map((s) => s.trim())
                     .filter(Boolean);
@@ -106,8 +108,10 @@ export default function postFilterList({ collection, mode }) {
         _buildAvailableTags(cards) {
             const map = new Map();
             cards.forEach(({ el }) => {
-                const slugs = (el.dataset.tags || '').split(',');
-                const names = (el.dataset.tagNames || '').split('|');
+                const inner = el.querySelector('[data-tags]');
+                if (!inner) return;
+                const slugs = (inner.dataset.tags || '').split(',');
+                const names = (inner.dataset.tagNames || '').split('|');
                 slugs.forEach((slug, i) => {
                     const s = slug.trim();
                     if (!s) return;

--- a/assets/js/typesense-search.js
+++ b/assets/js/typesense-search.js
@@ -1,15 +1,34 @@
 // Wrapper around Typesense's search REST API for the post-filter-list component.
 //
-// The TYPESENSE_API_KEY below is a *search-only* key — Typesense's analogue of
-// Ghost's Content API key. It is read-only and scoped to the `ghost` collection.
-// Embedding it client-side is intentional and safe (Typesense convention).
+// Configuration source of truth is `package.json` under `config.custom.typesense_*`,
+// admin-overridable in Ghost → Design → Customize → Search. `default.hbs` injects
+// the resolved values into `window.__TYPESENSE_CONFIG__` before this bundle loads.
+//
+// The API key is a *search-only* key — Typesense's analogue of Ghost's Content
+// API key. It is read-only and scoped to the configured collection. Embedding
+// it client-side is intentional and safe (Typesense convention).
 //
 // Schema verified live on 2026-05-06: collection holds 283 documents with
 // fields title, slug, excerpt, plaintext, tags.slug, published_at, etc.
 
-const TYPESENSE_HOST = 'https://typesense.advisory.sg';
-const TYPESENSE_API_KEY = 'LWQ1uyADTZBRVJa0XuFY5BcipgnhvQ8g';
-const TYPESENSE_COLLECTION = 'ghost';
+// Defaults match the Advisory SG production Typesense instance. They serve as
+// fallbacks when the inline config script is missing (e.g. partial page renders
+// without default.hbs) or returns empty values from an admin-cleared override.
+const DEFAULTS = {
+    host: 'https://typesense.advisory.sg',
+    apiKey: 'LWQ1uyADTZBRVJa0XuFY5BcipgnhvQ8g',
+    collection: 'ghost',
+};
+
+function getConfig() {
+    const cfg =
+        (typeof window !== 'undefined' && window.__TYPESENSE_CONFIG__) || {};
+    return {
+        host: cfg.host || DEFAULTS.host,
+        apiKey: cfg.apiKey || DEFAULTS.apiKey,
+        collection: cfg.collection || DEFAULTS.collection,
+    };
+}
 
 // Fields and weights — see spec.
 const QUERY_BY = 'title,excerpt,plaintext';
@@ -17,7 +36,7 @@ const QUERY_BY_WEIGHTS = '4,2,1';
 const PER_PAGE = 250;
 
 /**
- * Search the `ghost` collection and return matching post slugs.
+ * Search the configured Typesense collection and return matching post slugs.
  *
  * @param {string} query - Trimmed user query. Caller must ensure length >= 2.
  * @param {string[]} tagSlugs - Tag slugs scoping the search (the page's collection tags).
@@ -28,6 +47,8 @@ const PER_PAGE = 250;
  *                 AbortError is propagated as-is so callers can distinguish.
  */
 export async function searchSlugs(query, tagSlugs, signal) {
+    const { host, apiKey, collection } = getConfig();
+
     const params = new URLSearchParams({
         q: query,
         query_by: QUERY_BY,
@@ -39,9 +60,9 @@ export async function searchSlugs(query, tagSlugs, signal) {
         params.set('filter_by', `tags.slug:[${tagSlugs.join(',')}]`);
     }
 
-    const url = `${TYPESENSE_HOST}/collections/${TYPESENSE_COLLECTION}/documents/search?${params.toString()}`;
+    const url = `${host}/collections/${collection}/documents/search?${params.toString()}`;
     const response = await fetch(url, {
-        headers: { 'X-TYPESENSE-API-KEY': TYPESENSE_API_KEY },
+        headers: { 'X-TYPESENSE-API-KEY': apiKey },
         signal,
     });
     if (!response.ok) {

--- a/assets/js/typesense-search.js
+++ b/assets/js/typesense-search.js
@@ -1,0 +1,53 @@
+// Wrapper around Typesense's search REST API for the post-filter-list component.
+//
+// The TYPESENSE_API_KEY below is a *search-only* key — Typesense's analogue of
+// Ghost's Content API key. It is read-only and scoped to the `ghost` collection.
+// Embedding it client-side is intentional and safe (Typesense convention).
+//
+// Schema verified live on 2026-05-06: collection holds 283 documents with
+// fields title, slug, excerpt, plaintext, tags.slug, published_at, etc.
+
+const TYPESENSE_HOST = 'https://typesense.advisory.sg';
+const TYPESENSE_API_KEY = 'LWQ1uyADTZBRVJa0XuFY5BcipgnhvQ8g';
+const TYPESENSE_COLLECTION = 'ghost';
+
+// Fields and weights — see spec.
+const QUERY_BY = 'title,excerpt,plaintext';
+const QUERY_BY_WEIGHTS = '4,2,1';
+const PER_PAGE = 250;
+
+/**
+ * Search the `ghost` collection and return matching post slugs.
+ *
+ * @param {string} query - Trimmed user query. Caller must ensure length >= 2.
+ * @param {string[]} tagSlugs - Tag slugs scoping the search (the page's collection tags).
+ *                              If empty, no filter_by is sent.
+ * @param {AbortSignal} [signal] - Aborts the request if the caller's controller fires.
+ * @returns {Promise<Set<string>>} Resolves with the set of matching post slugs.
+ * @throws {Error} on network failure, non-2xx response, or malformed JSON.
+ *                 AbortError is propagated as-is so callers can distinguish.
+ */
+export async function searchSlugs(query, tagSlugs, signal) {
+    const params = new URLSearchParams({
+        q: query,
+        query_by: QUERY_BY,
+        query_by_weights: QUERY_BY_WEIGHTS,
+        include_fields: 'slug',
+        per_page: String(PER_PAGE),
+    });
+    if (tagSlugs && tagSlugs.length > 0) {
+        params.set('filter_by', `tags.slug:[${tagSlugs.join(',')}]`);
+    }
+
+    const url = `${TYPESENSE_HOST}/collections/${TYPESENSE_COLLECTION}/documents/search?${params.toString()}`;
+    const response = await fetch(url, {
+        headers: { 'X-TYPESENSE-API-KEY': TYPESENSE_API_KEY },
+        signal,
+    });
+    if (!response.ok) {
+        throw new Error(`Typesense HTTP ${response.status}`);
+    }
+    const data = await response.json();
+    const slugs = (data.hits || []).map((h) => h.document.slug);
+    return new Set(slugs);
+}

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -9,7 +9,7 @@ collections:
 
   /interviews/:
     permalink: /{year}/{month}/{day}/{slug}/
-    template: index
+    template: interviews
     filter: tag:[hash-conversations,hash-conversations-2,hash-conversations-3,hash-reflections,hash-reflections-2]
 
   /posts/:

--- a/default.hbs
+++ b/default.hbs
@@ -25,6 +25,17 @@
         var siteUrl = '{{@site.url}}';
     </script>
 
+    {{!-- Typesense search config — sourced from package.json config.custom,
+          overridable per-install in Ghost Admin → Design → Customize → Search.
+          The API key here is search-only (read-only, public-scoped). --}}
+    <script>
+        window.__TYPESENSE_CONFIG__ = {
+            host: '{{@custom.typesense_host}}',
+            apiKey: '{{@custom.typesense_api_key}}',
+            collection: '{{@custom.typesense_collection}}',
+        };
+    </script>
+
     {{ghost_head}}
 </head>
 

--- a/docs/superpowers/plans/2026-05-06-search-sort-fullload.md
+++ b/docs/superpowers/plans/2026-05-06-search-sort-fullload.md
@@ -1,0 +1,1333 @@
+# Search, Sort, and Full-corpus Load Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the existing tag-filter UI on `/events/` and `/interviews/` with a sort dropdown and a Typesense-backed search box, and fix the silent 100-post cap caused by `{{#get "posts" limit="all"}}`.
+
+**Architecture:** Stays SSR-first. The `{{#get}}` cap is fixed by stacking 20 explicit page calls (limit=100, page=1..20) via a new sub-partial — hard ceiling 2000 posts. Sort is client-side DOM reorder (`appendChild` rearranges `.filter-card-wrapper` nodes; CSS Grid follows DOM order). Search is server-side via Typesense's REST API: a small wrapper module turns a query string + page-tag-slug constraint into a `Set<slug>`; the existing Alpine component intersects that set with the chip filter to control card visibility. URL syncs `tags`, `q`, and `sort`.
+
+**Tech Stack:** Ghost theme (Handlebars partials, `routes.yaml`), Alpine.js (already a dep), Tailwind CSS (already a dep), webpack via gulp (already configured). New dep: none. New external: Typesense REST endpoint at `typesense.advisory.sg`.
+
+**Spec:** `docs/superpowers/specs/2026-05-06-search-sort-fullload-design.md`
+
+**Implementation order (per user):** full-corpus load → sort → search.
+
+## Working environment
+
+-   Local Ghost instance at `http://localhost:2368` with this theme installed.
+-   Build the theme one-shot: `npx gulp build` (compiles HBS, CSS, JS into `assets/built/`).
+-   Watch mode for active dev: `npm run dev` (build + livereload + watch). Leave it running in a separate terminal.
+-   Theme linter: `npm run test` (`gscan .`). Must show no errors. CI form: `npm run test:ci`.
+-   Pre-commit hook (husky + pretty-quick) runs Prettier on staged files. Don't fight it — let it reformat.
+-   Restart Ghost after any change to `routes.yaml`. (No `routes.yaml` change in this plan — but be aware.)
+-   All tasks commit to the current branch (`filter-addition`).
+-   Typesense schema verified live on 2026-05-06: collection `ghost`, 283 documents, fields include `title`, `slug`, `excerpt`, `plaintext`, `tags.slug`, `published_at`. The search-only API key in `assets/js/typesense-search.js` is intentionally public (read-only scope, Typesense convention).
+
+## File map
+
+**Created:**
+
+-   `partials/post-filter-page.hbs` — tiny sub-partial: one `{{#get limit=100 page=N filter=…}}` block.
+-   `assets/js/typesense-search.js` — wrapper exporting `searchSlugs(query, tagSlugs, signal): Promise<Set<string>>`.
+
+**Modified:**
+
+-   `partials/post-filter-list.hbs` — replace single `{{#get limit="all"}}` with 20 stacked sub-partial calls; add toolbar (sort + search); add error banner; adapt empty state and Clear-filters scope; add `id` to post grid for `aria-controls`.
+-   `partials/post-card.hbs` — add `data-slug`, `data-title`, `data-published-at` attributes on the root `<article>`.
+-   `assets/js/post-filter-list.js` — extend Alpine component: read new attributes; add `sortMode`, `searchQuery`, `searchSlugs`, `searchError`, `isSearching`, `tagSlugs`; add `_runSearch`, `_sorted`, `_reorderDom`; rename URL helpers to `_readStateFromUrl` / `_writeStateToUrl` (handle `tags`, `q`, `sort`); extend `clearFilters`; integrate search slug filter into `filtered()`.
+-   `events.hbs` — add `tagSlugs="hash-insights,hash-insights-2"` to the partial call.
+-   `interviews.hbs` — add `tagSlugs="hash-conversations,hash-conversations-2,hash-conversations-3,hash-reflections,hash-reflections-2"` to the partial call.
+
+**Untouched:**
+
+-   `assets/js/main.js` — component already registered.
+-   `config/routes.yaml` — tag lists stay there; templates duplicate them as `tagSlugs`.
+-   `index.hbs`, `tag.hbs`, any other listing — out of scope.
+-   CSS files — Tailwind utilities only, applied inline.
+
+---
+
+## Task 1: Full-corpus load — sub-partial + 20 stacked page blocks
+
+**Files:**
+
+-   Create: `partials/post-filter-page.hbs`
+-   Modify: `partials/post-filter-list.hbs:71-87` (the existing `{{#get limit="all"}}` block in the post grid)
+
+Ghost's `{{#get}}` helper silently caps `limit="all"` at 100 posts. Approach A from the spec: stack 20 explicit page=1..20 calls, each `limit=100`, factor the per-page block into a sub-partial to keep the parent readable. Pages past the end render empty.
+
+-   [ ] **Step 1: Create `partials/post-filter-page.hbs`**
+
+```handlebars
+{{!-- Renders one page (up to 100 posts) for post-filter-list.hbs.
+     Receives:
+       page    — string "1".."20" (Ghost's {{#get}} accepts string page arg)
+       filter  — Ghost filter expression (same one used on every page block)
+     Cards are wrapped in .filter-card-wrapper so the parent Alpine component
+     can show/hide them via x-show. --}}
+<!-- djlint:off -->
+{{#get "posts" limit="100" page=page filter=filter include="tags" order="published_at desc" as |posts|}}
+<!-- djlint:on -->
+    {{#foreach posts}}
+        <div
+            x-show="isVisible($el)"
+            tabindex="-1"
+            class="filter-card-wrapper">
+            {{> "post-card"}}
+        </div>
+    {{/foreach}}
+{{/get}}
+```
+
+-   [ ] **Step 2: Replace the post-grid block in `partials/post-filter-list.hbs`**
+
+Find this block (currently lines 71-87):
+
+```handlebars
+{{!-- Server-rendered post grid. NO x-cloak: JS-disabled users still see all posts. --}}
+<div class="post-feed container grid grid-cols-1 lg:grid-cols-3 gap-x-20 gap-y-10 m-auto">
+    <!-- djlint:off -->
+    {{#get "posts" limit="all" filter=filter include="tags" order="published_at desc" as |posts|}}
+    <!-- djlint:on -->
+        {{#foreach posts}}
+            {{!-- The wrapper is the filter unit: tagged via its [data-tags] child,
+                 focusable for keyboard users via tabindex="-1", and reactive via x-show. --}}
+            <div
+                x-show="isVisible($el)"
+                tabindex="-1"
+                class="filter-card-wrapper">
+                {{> "post-card"}}
+            </div>
+        {{/foreach}}
+    {{/get}}
+</div>
+```
+
+Replace with:
+
+```handlebars
+{{!-- Server-rendered post grid. 20 stacked page blocks (limit=100 each) work
+     around Ghost's silent 100-post cap on limit="all". Hard ceiling: 2000 posts.
+     NO x-cloak: JS-disabled users still see all posts. --}}
+<div id="post-grid-{{collection}}" class="post-feed container grid grid-cols-1 lg:grid-cols-3 gap-x-20 gap-y-10 m-auto">
+    {{> "post-filter-page" page="1" filter=filter}}
+    {{> "post-filter-page" page="2" filter=filter}}
+    {{> "post-filter-page" page="3" filter=filter}}
+    {{> "post-filter-page" page="4" filter=filter}}
+    {{> "post-filter-page" page="5" filter=filter}}
+    {{> "post-filter-page" page="6" filter=filter}}
+    {{> "post-filter-page" page="7" filter=filter}}
+    {{> "post-filter-page" page="8" filter=filter}}
+    {{> "post-filter-page" page="9" filter=filter}}
+    {{> "post-filter-page" page="10" filter=filter}}
+    {{> "post-filter-page" page="11" filter=filter}}
+    {{> "post-filter-page" page="12" filter=filter}}
+    {{> "post-filter-page" page="13" filter=filter}}
+    {{> "post-filter-page" page="14" filter=filter}}
+    {{> "post-filter-page" page="15" filter=filter}}
+    {{> "post-filter-page" page="16" filter=filter}}
+    {{> "post-filter-page" page="17" filter=filter}}
+    {{> "post-filter-page" page="18" filter=filter}}
+    {{> "post-filter-page" page="19" filter=filter}}
+    {{> "post-filter-page" page="20" filter=filter}}
+</div>
+```
+
+The `id="post-grid-{{collection}}"` is added now in preparation for the search input's `aria-controls` in Task 8 — harmless until then.
+
+-   [ ] **Step 3: Build and lint**
+
+```
+npx gulp build
+npm run test
+```
+
+Both should complete with no errors. `gscan` may emit informational notes but should not fail.
+
+-   [ ] **Step 4: Manually verify in browser**
+
+With `npm run dev` running and Ghost serving the theme:
+
+1. Load `http://localhost:2368/events/`. Open DevTools → Console, paste: `document.querySelectorAll('.filter-card-wrapper').length`. Should report the full count of events posts (more than 100).
+2. Same on `http://localhost:2368/interviews/`. Should report the full count.
+3. Counter ("Showing X of Y") should reflect the higher number, not be capped at 100.
+4. Click any tag chip. Filter should still narrow correctly.
+
+-   [ ] **Step 5: Commit**
+
+```
+git add partials/post-filter-page.hbs partials/post-filter-list.hbs
+git commit -m "fix(filter): full-corpus load via 20 stacked {{#get}} page blocks"
+```
+
+---
+
+## Task 2: Add `data-slug`, `data-title`, `data-published-at` to `post-card.hbs`
+
+**Files:**
+
+-   Modify: `partials/post-card.hbs:1-4`
+
+Add three attributes the Alpine component needs for sort and search. `data-published-at` uses a lexically-sortable, second-precision format. `data-slug` is the join key for Typesense results. `data-title` is for the title sort comparator.
+
+-   [ ] **Step 1: Edit the root `<article>` element**
+
+Find lines 1-4:
+
+```handlebars
+<article
+    class="feed-card {{post_class}} rounded-lg shadow-2xl m-auto w-full max-w-2xl md:max-w-full lg:h-full hover:shadow-md hover:border-opacity-0 transform hover:-translate-y-1 transition-all duration-200"
+    data-tags="{{#foreach tags visibility='public'}}{{slug}}{{#unless @last}},{{/unless}}{{/foreach}}"
+    data-tag-names="{{#foreach tags visibility='public'}}{{name}}{{#unless @last}}|{{/unless}}{{/foreach}}">
+```
+
+Replace with:
+
+```handlebars
+<article
+    class="feed-card {{post_class}} rounded-lg shadow-2xl m-auto w-full max-w-2xl md:max-w-full lg:h-full hover:shadow-md hover:border-opacity-0 transform hover:-translate-y-1 transition-all duration-200"
+    data-tags="{{#foreach tags visibility='public'}}{{slug}}{{#unless @last}},{{/unless}}{{/foreach}}"
+    data-tag-names="{{#foreach tags visibility='public'}}{{name}}{{#unless @last}}|{{/unless}}{{/foreach}}"
+    data-slug="{{slug}}"
+    data-title="{{title}}"
+    data-published-at="{{date published_at format='YYYY-MM-DD HH:mm:ss'}}">
+```
+
+Format `'YYYY-MM-DD HH:mm:ss'` is lexically sortable (so a string comparator works for date sort) and explicit about the `published_at` field (Ghost's `{{date}}` helper requires the field arg to avoid relying on context defaults).
+
+-   [ ] **Step 2: Build and lint**
+
+```
+npx gulp build
+npm run test
+```
+
+-   [ ] **Step 3: Manually verify in browser**
+
+Reload `http://localhost:2368/events/`. Inspect any `.feed-card`. Confirm all five `data-*` attributes are present:
+
+```
+data-tags="..."
+data-tag-names="..."
+data-slug="conversations-with-..."  (or the post's actual slug)
+data-title="..."
+data-published-at="2024-03-15 10:30:00"  (or similar; valid ISO-ish format)
+```
+
+-   [ ] **Step 4: Commit**
+
+```
+git add partials/post-card.hbs
+git commit -m "feat(post-card): expose slug, title, published-at as data attributes"
+```
+
+---
+
+## Task 3: Sort state, sort pipeline, URL state refactor
+
+**Files:**
+
+-   Modify: `assets/js/post-filter-list.js` (whole file)
+
+Add the sort feature in JS without UI yet. Three intertwined changes:
+
+1. Extend `_readCardsFromDom` to capture `slug`, `title`, `publishedAt` per card (slug used in Task 7's search; title and publishedAt used here for sort).
+2. Add `sortMode` state, `_sorted(cards)` comparator, and `_reorderDom()` that rearranges DOM nodes via `appendChild` to match the sort order.
+3. Replace `_readTagsFromUrl` / `_writeTagsToUrl` with `_readStateFromUrl` / `_writeStateToUrl` that handle `tags` and `sort` (and leave room for `q` in Task 7).
+
+-   [ ] **Step 1: Replace `assets/js/post-filter-list.js` with the full updated component**
+
+```javascript
+// Alpine component for client-side multi-tag filter, sort, search, load-more, and URL sync.
+// Used by partials/post-filter-list.hbs on /events/ and /interviews/.
+//
+// Call site:
+//   <div x-data="postFilterList({ collection: 'events', mode: 'or', tagSlugs: 'hash-insights,...' })" ...>
+//
+// Parameters:
+//   collection: passed through for the partial's DOM id namespace; not used here.
+//   mode: 'or' (default) or 'and'. Selects matching function for chips.
+//   tagSlugs: comma-separated string of tag slugs scoping this collection (used by Task 7 for Typesense filter_by). Not consumed in Task 3.
+export default function postFilterList({ collection, mode, tagSlugs }) {
+    const PAGE_SIZE = 12;
+
+    return {
+        // --- state -------------------------------------------------------
+        selectedTags: [],
+        sortMode: "newest", // 'newest' | 'oldest' | 'az' | 'za'
+        visibleCount: PAGE_SIZE,
+        allCards: [],
+        availableTags: [],
+        tagSlugs: (tagSlugs || "")
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean),
+
+        // --- lifecycle ---------------------------------------------------
+
+        init() {
+            this.allCards = this._readCardsFromDom();
+            this.availableTags = this._buildAvailableTags(this.allCards);
+
+            const state = this._readStateFromUrl();
+            this.selectedTags = state.tags;
+            this.sortMode = state.sort;
+
+            this.$watch("selectedTags", () => {
+                this.visibleCount = PAGE_SIZE;
+                this._writeStateToUrl();
+            });
+            this.$watch("sortMode", () => {
+                this.visibleCount = PAGE_SIZE;
+                this._reorderDom();
+                this._writeStateToUrl();
+            });
+
+            // Apply initial DOM order if URL specified a non-default sort.
+            if (this.sortMode !== "newest") {
+                this._reorderDom();
+            }
+        },
+
+        // --- queries -----------------------------------------------------
+
+        matches(card) {
+            if (this.selectedTags.length === 0) return true;
+            if (mode === "and") {
+                return this.selectedTags.every((t) => card.tagSlugs.has(t));
+            }
+            return this.selectedTags.some((t) => card.tagSlugs.has(t));
+        },
+
+        filtered() {
+            const tagFiltered = this.allCards.filter((c) => this.matches(c));
+            // Search filter (added in Task 7).
+            return this._sorted(tagFiltered);
+        },
+
+        visible() {
+            return this.filtered().slice(0, this.visibleCount);
+        },
+
+        // el must be the .filter-card-wrapper element (the same node stored in allCards).
+        // The wrapper carries tabindex="-1" so loadMore() can focus it.
+        isVisible(el) {
+            return this.visible().some((c) => c.el === el);
+        },
+
+        unknownTags() {
+            const known = new Set(this.availableTags.map((t) => t.slug));
+            return this.selectedTags.filter((s) => !known.has(s));
+        },
+
+        hasMore() {
+            return this.filtered().length > this.visibleCount;
+        },
+
+        // --- actions -----------------------------------------------------
+
+        isSelected(slug) {
+            return this.selectedTags.includes(slug);
+        },
+
+        toggleTag(slug) {
+            if (this.isSelected(slug)) {
+                this.selectedTags = this.selectedTags.filter((s) => s !== slug);
+            } else {
+                this.selectedTags = [...this.selectedTags, slug];
+            }
+        },
+
+        loadMore() {
+            this.visibleCount += PAGE_SIZE;
+            // Move focus to the first newly-revealed card for keyboard users.
+            this.$nextTick(() => {
+                const newIndex = this.visibleCount - PAGE_SIZE;
+                const card = this.filtered()[newIndex];
+                if (card && card.el) card.el.focus();
+            });
+        },
+
+        clearFilters() {
+            this.selectedTags = [];
+            this.sortMode = "newest";
+            // Search reset added in Task 7.
+        },
+
+        // --- internals ---------------------------------------------------
+
+        _sorted(cards) {
+            const sorted = [...cards];
+            switch (this.sortMode) {
+                case "oldest":
+                    sorted.sort((a, b) =>
+                        a.publishedAt.localeCompare(b.publishedAt),
+                    );
+                    break;
+                case "az":
+                    sorted.sort((a, b) => a.title.localeCompare(b.title));
+                    break;
+                case "za":
+                    sorted.sort((a, b) => b.title.localeCompare(a.title));
+                    break;
+                case "newest":
+                default:
+                    sorted.sort((a, b) =>
+                        b.publishedAt.localeCompare(a.publishedAt),
+                    );
+                    break;
+            }
+            return sorted;
+        },
+
+        // Reorders ALL .filter-card-wrapper nodes in the grid to match the current sort.
+        // Hidden cards (x-show=false) reorder along with visible ones; CSS Grid then
+        // lays out only the visible ones in their new DOM order.
+        _reorderDom() {
+            if (this.allCards.length === 0) return;
+            const grid = this.allCards[0].el.parentNode;
+            if (!grid) return;
+            const sorted = this._sorted(this.allCards);
+            sorted.forEach((c) => grid.appendChild(c.el));
+        },
+
+        _readCardsFromDom() {
+            const root = this.$root || this.$el;
+            const wrappers = root.querySelectorAll(".filter-card-wrapper");
+            return Array.from(wrappers).map((el) => {
+                const inner = el.querySelector("[data-tags]");
+                const slugs = (
+                    inner && inner.dataset.tags ? inner.dataset.tags : ""
+                )
+                    .split(",")
+                    .map((s) => s.trim())
+                    .filter(Boolean);
+                return {
+                    el,
+                    tagSlugs: new Set(slugs),
+                    slug: (inner && inner.dataset.slug) || "",
+                    title: (inner && inner.dataset.title) || "",
+                    publishedAt: (inner && inner.dataset.publishedAt) || "",
+                };
+            });
+        },
+
+        _buildAvailableTags(cards) {
+            const map = new Map();
+            cards.forEach(({ el }) => {
+                const inner = el.querySelector("[data-tags]");
+                if (!inner) return;
+                const slugs = (inner.dataset.tags || "").split(",");
+                const names = (inner.dataset.tagNames || "").split("|");
+                slugs.forEach((slug, i) => {
+                    const s = slug.trim();
+                    if (!s) return;
+                    if (!map.has(s)) {
+                        map.set(s, { slug: s, name: (names[i] || s).trim() });
+                    }
+                });
+            });
+            return Array.from(map.values()).sort((a, b) =>
+                a.name.localeCompare(b.name),
+            );
+        },
+
+        _readStateFromUrl() {
+            const params = new URLSearchParams(window.location.search);
+
+            const tags = (params.get("tags") || "")
+                .split(",")
+                .map((s) => s.trim())
+                .filter(Boolean);
+
+            const rawSort = params.get("sort") || "newest";
+            const validSorts = ["newest", "oldest", "az", "za"];
+            const sort = validSorts.includes(rawSort) ? rawSort : "newest";
+
+            return { tags, sort };
+        },
+
+        _writeStateToUrl() {
+            const params = new URLSearchParams(window.location.search);
+
+            if (this.selectedTags.length) {
+                params.set("tags", this.selectedTags.join(","));
+            } else {
+                params.delete("tags");
+            }
+
+            if (this.sortMode && this.sortMode !== "newest") {
+                params.set("sort", this.sortMode);
+            } else {
+                params.delete("sort");
+            }
+
+            const qs = params.toString();
+            const newUrl = qs
+                ? `${window.location.pathname}?${qs}`
+                : window.location.pathname;
+            window.history.replaceState(null, "", newUrl);
+        },
+    };
+}
+```
+
+-   [ ] **Step 2: Build and lint**
+
+```
+npx gulp build
+npm run test
+```
+
+-   [ ] **Step 3: Manually verify in browser (DevTools console)**
+
+Reload `http://localhost:2368/events/`. Open DevTools → Console:
+
+```javascript
+// Confirm the new fields are populated.
+const c = Alpine.$data(document.querySelector('[x-data^="postFilterList"]'));
+console.log(
+    c.allCards
+        .slice(0, 3)
+        .map((x) => ({
+            slug: x.slug,
+            title: x.title.slice(0, 30),
+            publishedAt: x.publishedAt,
+        })),
+);
+// Should show 3 entries with non-empty slug/title/publishedAt.
+
+// Trigger sort change.
+c.sortMode = "oldest";
+// Cards should visually reorder. URL should now have ?sort=oldest.
+
+c.sortMode = "az";
+// Cards reorder alphabetically. URL ?sort=az.
+
+c.sortMode = "newest";
+// Cards return to original order. URL drops the sort param.
+```
+
+Reload `http://localhost:2368/events/?sort=oldest`. Cards should appear oldest-first on initial paint.
+
+-   [ ] **Step 4: Commit**
+
+```
+git add assets/js/post-filter-list.js
+git commit -m "feat(filter): add client-side sort with URL sync"
+```
+
+---
+
+## Task 4: Sort dropdown UI
+
+**Files:**
+
+-   Modify: `partials/post-filter-list.hbs:11-39` (region just inside the root div, above the chips block)
+
+Add a toolbar row above the chips containing a native `<select>` bound to `sortMode`. Search input is added to the same toolbar in Task 8.
+
+-   [ ] **Step 1: Insert the toolbar block in `partials/post-filter-list.hbs`**
+
+Find the root `<div x-data="postFilterList(...)">` opening (line 7-10). Immediately after the opening `<div ...>` (line 10) and before the existing `{{!-- Filter chips: ... --}}` comment (line 12), insert:
+
+```handlebars
+{{! Toolbar: sort dropdown (and search input — added in Task 8). }}
+<div
+    x-cloak
+    class="post-filter-toolbar container m-auto px-4 mb-4 flex flex-wrap gap-3 items-center justify-end"
+>
+    <div class="flex items-center gap-2">
+        <label
+            for="post-sort-{{collection}}"
+            class="text-base text-gray-700"
+        >Sort:</label>
+        <select
+            id="post-sort-{{collection}}"
+            x-model="sortMode"
+            class="px-3 py-2 rounded border border-gray-300 text-base"
+        >
+            <option value="newest">Newest first</option>
+            <option value="oldest">Oldest first</option>
+            <option value="az">Title A → Z</option>
+            <option value="za">Title Z → A</option>
+        </select>
+    </div>
+</div>
+```
+
+Notes:
+
+-   `x-cloak` hides the toolbar until Alpine inits (otherwise the dropdown would briefly show a stale value during URL-seeded loads).
+-   `justify-end` right-aligns the dropdown for now. Task 8 will change this to `justify-between` once the search input occupies the left side.
+
+-   [ ] **Step 2: Build and lint**
+
+```
+npx gulp build
+npm run test
+```
+
+-   [ ] **Step 3: Manually verify in browser**
+
+Reload `http://localhost:2368/events/`. The sort dropdown should appear above the chip row, right-aligned. Changing it should reorder the cards. Reload `?sort=az` should pre-select "Title A → Z" and show alphabetical order.
+
+Same on `http://localhost:2368/interviews/`.
+
+-   [ ] **Step 4: Commit**
+
+```
+git add partials/post-filter-list.hbs
+git commit -m "feat(filter): add sort dropdown to toolbar"
+```
+
+---
+
+## Task 5: Create `assets/js/typesense-search.js` wrapper
+
+**Files:**
+
+-   Create: `assets/js/typesense-search.js`
+
+Self-contained module. Three constants at the top (host, key, collection), one exported function. No state. The Alpine component will own the AbortController; this module just accepts the signal and passes it to `fetch`.
+
+-   [ ] **Step 1: Create `assets/js/typesense-search.js`**
+
+```javascript
+// Wrapper around Typesense's search REST API for the post-filter-list component.
+//
+// The TYPESENSE_API_KEY below is a *search-only* key — Typesense's analogue of
+// Ghost's Content API key. It is read-only and scoped to the `ghost` collection.
+// Embedding it client-side is intentional and safe (Typesense convention).
+//
+// Schema verified live on 2026-05-06: collection holds 283 documents with
+// fields title, slug, excerpt, plaintext, tags.slug, published_at, etc.
+
+const TYPESENSE_HOST = "https://typesense.advisory.sg";
+const TYPESENSE_API_KEY = "LWQ1uyADTZBRVJa0XuFY5BcipgnhvQ8g";
+const TYPESENSE_COLLECTION = "ghost";
+
+// Fields and weights — see spec.
+const QUERY_BY = "title,excerpt,plaintext";
+const QUERY_BY_WEIGHTS = "4,2,1";
+const PER_PAGE = 250;
+
+/**
+ * Search the `ghost` collection and return matching post slugs.
+ *
+ * @param {string} query - Trimmed user query. Caller must ensure length >= 2.
+ * @param {string[]} tagSlugs - Tag slugs scoping the search (the page's collection tags).
+ *                              If empty, no filter_by is sent.
+ * @param {AbortSignal} [signal] - Aborts the request if the caller's controller fires.
+ * @returns {Promise<Set<string>>} Resolves with the set of matching post slugs.
+ * @throws {Error} on network failure, non-2xx response, or malformed JSON.
+ *                 AbortError is propagated as-is so callers can distinguish.
+ */
+export async function searchSlugs(query, tagSlugs, signal) {
+    const params = new URLSearchParams({
+        q: query,
+        query_by: QUERY_BY,
+        query_by_weights: QUERY_BY_WEIGHTS,
+        include_fields: "slug",
+        per_page: String(PER_PAGE),
+    });
+    if (tagSlugs && tagSlugs.length > 0) {
+        params.set("filter_by", `tags.slug:[${tagSlugs.join(",")}]`);
+    }
+
+    const url = `${TYPESENSE_HOST}/collections/${TYPESENSE_COLLECTION}/documents/search?${params.toString()}`;
+    const response = await fetch(url, {
+        headers: { "X-TYPESENSE-API-KEY": TYPESENSE_API_KEY },
+        signal,
+    });
+    if (!response.ok) {
+        throw new Error(`Typesense HTTP ${response.status}`);
+    }
+    const data = await response.json();
+    const slugs = (data.hits || []).map((h) => h.document.slug);
+    return new Set(slugs);
+}
+```
+
+-   [ ] **Step 2: Build and lint**
+
+```
+npx gulp build
+npm run test
+```
+
+The build should bundle the new file into `assets/built/main.js` only once it's imported (Task 7). For now it just compiles standalone via webpack's module resolution.
+
+-   [ ] **Step 3: Manually verify in browser (DevTools console)**
+
+Open `http://localhost:2368/events/`. Open DevTools → Console. Paste a one-off probe (the function isn't yet imported anywhere, so we test via direct fetch using the same shape):
+
+```javascript
+fetch(
+    "https://typesense.advisory.sg/collections/ghost/documents/search?q=stoic&query_by=title,excerpt,plaintext&query_by_weights=4,2,1&include_fields=slug&per_page=250",
+    {
+        headers: { "X-TYPESENSE-API-KEY": "LWQ1uyADTZBRVJa0XuFY5BcipgnhvQ8g" },
+    },
+)
+    .then((r) => r.json())
+    .then((d) =>
+        console.log(
+            "found",
+            d.found,
+            "sample slugs:",
+            d.hits.slice(0, 3).map((h) => h.document.slug),
+        ),
+    );
+```
+
+Expected: a `found` count and 0-3 slug strings logged. CORS preflight must succeed; if it fails, Typesense host's CORS config is the issue (operational, fix outside this plan).
+
+-   [ ] **Step 4: Commit**
+
+```
+git add assets/js/typesense-search.js
+git commit -m "feat(search): add Typesense search wrapper"
+```
+
+---
+
+## Task 6: Thread `tagSlugs` from page templates into the partial and component
+
+**Files:**
+
+-   Modify: `partials/post-filter-list.hbs:7-10` (root `<div>` `x-data` attribute)
+-   Modify: `events.hbs` (the `{{> post-filter-list ...}}` call)
+-   Modify: `interviews.hbs` (the `{{> post-filter-list ...}}` call)
+
+The Typesense collection holds _all_ Ghost posts. To prevent search results bleeding across collections, every search request must carry `filter_by=tags.slug:[<page tags>]`. The slug list comes from `routes.yaml` and is duplicated into each page template as a `tagSlugs` parameter, then threaded through the partial into the Alpine component (which already accepts `tagSlugs` after Task 3).
+
+-   [ ] **Step 1: Update `partials/post-filter-list.hbs` root to pass `tagSlugs` into Alpine**
+
+Find lines 7-10 (currently):
+
+```handlebars
+<div
+    id="post-filter-{{collection}}"
+    x-data="postFilterList({ collection: '{{collection}}', mode: '{{mode}}' })"
+    class="post-filter-list">
+```
+
+Replace with:
+
+```handlebars
+<div
+    id="post-filter-{{collection}}"
+    x-data="postFilterList({ collection: '{{collection}}', mode: '{{mode}}', tagSlugs: '{{tagSlugs}}' })"
+    class="post-filter-list">
+```
+
+-   [ ] **Step 2: Update `events.hbs` partial call**
+
+Find the line:
+
+```handlebars
+{{> post-filter-list collection="events" filter="tag:[hash-insights,hash-insights-2]" mode="or"}}
+```
+
+Replace with:
+
+```handlebars
+{{> post-filter-list collection="events" filter="tag:[hash-insights,hash-insights-2]" tagSlugs="hash-insights,hash-insights-2" mode="or"}}
+```
+
+-   [ ] **Step 3: Update `interviews.hbs` partial call**
+
+Find the line:
+
+```handlebars
+{{> post-filter-list collection="interviews" filter="tag:[hash-conversations,hash-conversations-2,hash-conversations-3,hash-reflections,hash-reflections-2]" mode="or"}}
+```
+
+Replace with:
+
+```handlebars
+{{> post-filter-list collection="interviews" filter="tag:[hash-conversations,hash-conversations-2,hash-conversations-3,hash-reflections,hash-reflections-2]" tagSlugs="hash-conversations,hash-conversations-2,hash-conversations-3,hash-reflections,hash-reflections-2" mode="or"}}
+```
+
+(Yes, the slug list appears twice in each call — once for Ghost's `{{#get}}` filter expression, once as a plain comma-separated string for Typesense. Source of truth remains `routes.yaml`.)
+
+-   [ ] **Step 4: Build and lint**
+
+```
+npx gulp build
+npm run test
+```
+
+-   [ ] **Step 5: Manually verify in browser (DevTools console)**
+
+Reload `http://localhost:2368/events/`. Console:
+
+```javascript
+const c = Alpine.$data(document.querySelector('[x-data^="postFilterList"]'));
+console.log(c.tagSlugs);
+// Should print: ['hash-insights', 'hash-insights-2']
+```
+
+Same on interviews — should print the 5-element array.
+
+-   [ ] **Step 6: Commit**
+
+```
+git add partials/post-filter-list.hbs events.hbs interviews.hbs
+git commit -m "feat(filter): thread page tagSlugs into Alpine component for search scoping"
+```
+
+---
+
+## Task 7: Search state, debounced fetch, AbortController, integration into filter pipeline
+
+**Files:**
+
+-   Modify: `assets/js/post-filter-list.js` (add import; extend state, init, filtered, clearFilters; add `_runSearch`, `setSearchQuery`; extend URL state)
+
+Wire the Typesense wrapper into the component. UI for the search input lands in Task 8 — for now the state is testable from the console.
+
+-   [ ] **Step 1: Add the import at the top of `assets/js/post-filter-list.js`**
+
+At the very top of the file, before the existing comment header, add:
+
+```javascript
+import { searchSlugs } from "./typesense-search.js";
+```
+
+-   [ ] **Step 2: Extend the returned state object**
+
+Inside the `return { ... }` block, find the `--- state ---` section. After `tagSlugs: ...,` add:
+
+```javascript
+        searchQuery: '',
+        searchSlugs: null, // null = no search active or query < 2 chars; Set = Typesense results
+        searchError: false,
+        isSearching: false,
+        _searchAbortController: null,
+        _searchDebounceTimer: null,
+```
+
+The two underscore-prefixed fields are non-reactive runtime handles (Alpine will still proxy them, but we never bind to them in templates). Keeping them on the component avoids module-level state.
+
+-   [ ] **Step 3: Extend `init()` to seed search from URL and watch `searchQuery`**
+
+Replace the existing `init()` body with:
+
+```javascript
+        init() {
+            this.allCards = this._readCardsFromDom();
+            this.availableTags = this._buildAvailableTags(this.allCards);
+
+            const state = this._readStateFromUrl();
+            this.selectedTags = state.tags;
+            this.sortMode = state.sort;
+            this.searchQuery = state.q;
+
+            this.$watch('selectedTags', () => {
+                this.visibleCount = PAGE_SIZE;
+                this._writeStateToUrl();
+            });
+            this.$watch('sortMode', () => {
+                this.visibleCount = PAGE_SIZE;
+                this._reorderDom();
+                this._writeStateToUrl();
+            });
+
+            // Apply initial DOM order if URL specified a non-default sort.
+            if (this.sortMode !== 'newest') {
+                this._reorderDom();
+            }
+
+            // Fire a search if URL had ?q=… on load.
+            if (this.searchQuery.trim().length >= 2) {
+                this._runSearch();
+            }
+        },
+```
+
+-   [ ] **Step 4: Update `filtered()` to apply the search filter**
+
+Replace the existing `filtered()` body with:
+
+```javascript
+        filtered() {
+            let result = this.allCards.filter((c) => this.matches(c));
+            if (this.searchSlugs !== null) {
+                result = result.filter((c) => this.searchSlugs.has(c.slug));
+            }
+            return this._sorted(result);
+        },
+```
+
+-   [ ] **Step 5: Update `clearFilters()` to reset all state**
+
+Replace the existing `clearFilters()` body with:
+
+```javascript
+        clearFilters() {
+            this.selectedTags = [];
+            this.sortMode = 'newest';
+            this.searchQuery = '';
+            this.searchSlugs = null;
+            this.searchError = false;
+        },
+```
+
+-   [ ] **Step 6: Add `setSearchQuery` and `_runSearch` to the component**
+
+Inside the `--- actions ---` section, before `clearFilters`, add:
+
+```javascript
+        setSearchQuery(value) {
+            this.searchQuery = value;
+            clearTimeout(this._searchDebounceTimer);
+            this._searchDebounceTimer = setTimeout(() => {
+                this._runSearch();
+            }, 250);
+        },
+```
+
+Inside the `--- internals ---` section, after `_reorderDom()`, add:
+
+```javascript
+        async _runSearch() {
+            const trimmed = this.searchQuery.trim();
+
+            // Cancel any in-flight request — newer query supersedes it.
+            if (this._searchAbortController) {
+                this._searchAbortController.abort();
+            }
+
+            // Short-circuit: <2 chars means no search active.
+            if (trimmed.length < 2) {
+                this.searchSlugs = null;
+                this.searchError = false;
+                this.isSearching = false;
+                this.visibleCount = PAGE_SIZE;
+                this._writeStateToUrl();
+                return;
+            }
+
+            this._searchAbortController = new AbortController();
+            this.isSearching = true;
+
+            try {
+                const slugs = await searchSlugs(
+                    trimmed,
+                    this.tagSlugs,
+                    this._searchAbortController.signal,
+                );
+                this.searchSlugs = slugs;
+                this.searchError = false;
+                this.visibleCount = PAGE_SIZE;
+                this._writeStateToUrl();
+            } catch (err) {
+                if (err.name === 'AbortError') return; // newer query is in flight
+                this.searchSlugs = null;
+                this.searchError = true;
+            } finally {
+                this.isSearching = false;
+            }
+        },
+```
+
+-   [ ] **Step 7: Extend `_readStateFromUrl` and `_writeStateToUrl` to handle `q`**
+
+Replace the existing `_readStateFromUrl` body with:
+
+```javascript
+        _readStateFromUrl() {
+            const params = new URLSearchParams(window.location.search);
+
+            const tags = (params.get('tags') || '')
+                .split(',')
+                .map((s) => s.trim())
+                .filter(Boolean);
+
+            const rawSort = params.get('sort') || 'newest';
+            const validSorts = ['newest', 'oldest', 'az', 'za'];
+            const sort = validSorts.includes(rawSort) ? rawSort : 'newest';
+
+            const q = params.get('q') || '';
+
+            return { tags, sort, q };
+        },
+```
+
+Replace the existing `_writeStateToUrl` body with:
+
+```javascript
+        _writeStateToUrl() {
+            const params = new URLSearchParams(window.location.search);
+
+            if (this.selectedTags.length) {
+                params.set('tags', this.selectedTags.join(','));
+            } else {
+                params.delete('tags');
+            }
+
+            if (this.sortMode && this.sortMode !== 'newest') {
+                params.set('sort', this.sortMode);
+            } else {
+                params.delete('sort');
+            }
+
+            const q = (this.searchQuery || '').trim();
+            if (q.length >= 2) {
+                params.set('q', q);
+            } else {
+                params.delete('q');
+            }
+
+            const qs = params.toString();
+            const newUrl = qs
+                ? `${window.location.pathname}?${qs}`
+                : window.location.pathname;
+            window.history.replaceState(null, '', newUrl);
+        },
+```
+
+-   [ ] **Step 8: Build and lint**
+
+```
+npx gulp build
+npm run test
+```
+
+-   [ ] **Step 9: Manually verify in browser (DevTools console)**
+
+Reload `http://localhost:2368/events/`. Console:
+
+```javascript
+const c = Alpine.$data(document.querySelector('[x-data^="postFilterList"]'));
+
+// Trigger a search programmatically (simulates UI input).
+c.setSearchQuery("stoic");
+
+// Wait ~500ms then inspect.
+setTimeout(() => {
+    console.log(
+        "searchSlugs size:",
+        c.searchSlugs?.size,
+        "isSearching:",
+        c.isSearching,
+        "searchError:",
+        c.searchError,
+    );
+    console.log("visible count:", c.visible().length);
+    console.log("URL:", location.search);
+}, 600);
+```
+
+Expected:
+
+-   `searchSlugs` is a `Set` with 0+ entries.
+-   `isSearching` is `false` (request completed).
+-   `visible count` reflects the intersection of search results with loaded cards.
+-   URL has `?q=stoic`.
+
+Reload `http://localhost:2368/events/?q=banking`. Console — search should fire on init, narrow results.
+
+Test the abort path:
+
+```javascript
+c.setSearchQuery("a"); // <2 chars → searchSlugs = null
+c.setSearchQuery("ab"); // fires search
+c.setSearchQuery("abc"); // aborts the prior, fires new
+```
+
+Network panel: only the latest request should complete; earlier ones show `cancelled` status.
+
+Test error path: in DevTools → Network, right-click → Block request URL on the Typesense host. Then `c.setSearchQuery('test')`. Wait. `c.searchError` should become `true`. Unblock URL.
+
+-   [ ] **Step 10: Commit**
+
+```
+git add assets/js/post-filter-list.js
+git commit -m "feat(search): integrate Typesense search into filter pipeline"
+```
+
+---
+
+## Task 8: Search input UI, searching indicator, error banner, empty-state copy, Clear-filters scope
+
+**Files:**
+
+-   Modify: `partials/post-filter-list.hbs` (toolbar block, chip-row Clear button, empty state, error banner)
+
+Add the search input to the toolbar (left side, flex-1) alongside the existing sort dropdown (right side). Add a `Searching…` indicator. Add a Typesense-error banner. Adapt the empty-state copy to mention search. Extend the Clear-filters button visibility to also trigger when search or sort is active.
+
+-   [ ] **Step 1: Replace the toolbar block in `partials/post-filter-list.hbs`**
+
+Find the toolbar block added in Task 4:
+
+```handlebars
+{{! Toolbar: sort dropdown (and search input — added in Task 8). }}
+<div
+    x-cloak
+    class="post-filter-toolbar container m-auto px-4 mb-4 flex flex-wrap gap-3 items-center justify-end"
+>
+    <div class="flex items-center gap-2">
+        <label
+            for="post-sort-{{collection}}"
+            class="text-base text-gray-700"
+        >Sort:</label>
+        <select
+            id="post-sort-{{collection}}"
+            x-model="sortMode"
+            class="px-3 py-2 rounded border border-gray-300 text-base"
+        >
+            <option value="newest">Newest first</option>
+            <option value="oldest">Oldest first</option>
+            <option value="az">Title A → Z</option>
+            <option value="za">Title Z → A</option>
+        </select>
+    </div>
+</div>
+```
+
+Replace with:
+
+```handlebars
+{{! Toolbar: search input (left, flex-1) + sort dropdown (right). }}
+<div
+    x-cloak
+    class="post-filter-toolbar container m-auto px-4 mb-4 flex flex-wrap gap-3 items-center"
+>
+    <div class="flex-1 min-w-[200px] flex items-center gap-2">
+        <label for="post-search-{{collection}}" class="sr-only">Search posts</label>
+        <input
+            id="post-search-{{collection}}"
+            type="search"
+            placeholder="Search posts..."
+            :value="searchQuery"
+            @input="setSearchQuery($event.target.value)"
+            @keydown.escape="setSearchQuery(''); $event.target.focus()"
+            aria-controls="post-grid-{{collection}}"
+            class="flex-1 px-3 py-2 rounded border border-gray-300 text-base"
+        />
+        <span
+            x-show="isSearching"
+            aria-live="polite"
+            class="text-base text-gray-600 whitespace-nowrap"
+        >
+            Searching…
+        </span>
+    </div>
+    <div class="flex items-center gap-2">
+        <label
+            for="post-sort-{{collection}}"
+            class="text-base text-gray-700"
+        >Sort:</label>
+        <select
+            id="post-sort-{{collection}}"
+            x-model="sortMode"
+            class="px-3 py-2 rounded border border-gray-300 text-base"
+        >
+            <option value="newest">Newest first</option>
+            <option value="oldest">Oldest first</option>
+            <option value="az">Title A → Z</option>
+            <option value="za">Title Z → A</option>
+        </select>
+    </div>
+</div>
+
+{{! Search error banner }}
+<div
+    x-cloak
+    x-show="searchError"
+    role="alert"
+    class="container m-auto px-4 mb-4 p-3 rounded border bg-red-50 border-red-200 text-red-900 text-base"
+>
+    Search temporarily unavailable. Filters and sorting still work.
+</div>
+```
+
+-   [ ] **Step 2: Extend the chip-row Clear-filters button visibility**
+
+Find the existing chip-row Clear-filters button (currently inside the `filter-chips` div):
+
+```handlebars
+<button
+    type="button"
+    @click="clearFilters()"
+    x-show="selectedTags.length > 0"
+    class="px-4 py-2 rounded-full text-base text-gray-700 underline hover:text-gray-900"
+>
+    Clear filters
+</button>
+```
+
+Replace the `x-show` attribute:
+
+```handlebars
+<button
+    type="button"
+    @click="clearFilters()"
+    x-show="selectedTags.length > 0 || searchQuery.trim().length > 0 || sortMode !== 'newest'"
+    class="px-4 py-2 rounded-full text-base text-gray-700 underline hover:text-gray-900"
+>
+    Clear filters
+</button>
+```
+
+-   [ ] **Step 3: Adapt the empty-state copy**
+
+Find the empty state block:
+
+```handlebars
+{{! Empty state }}
+<div
+    x-cloak
+    x-show="filtered().length === 0"
+    class="container m-auto px-4 py-12 text-center text-xl text-gray-700"
+>
+    <p>No posts match your selected tags.</p>
+    <button
+        type="button"
+        @click="clearFilters()"
+        x-show="selectedTags.length > 0"
+        class="mt-4 px-4 py-2 rounded-full border border-gray-900 text-base hover:bg-gray-900 hover:text-white transition-colors"
+    >
+        Clear filters
+    </button>
+</div>
+```
+
+Replace the entire block with:
+
+```handlebars
+{{! Empty state }}
+<div
+    x-cloak
+    x-show="filtered().length === 0"
+    class="container m-auto px-4 py-12 text-center text-xl text-gray-700"
+>
+    <p x-show="searchQuery.trim().length > 0 && selectedTags.length > 0">No
+        posts match your search and filters.</p>
+    <p x-show="searchQuery.trim().length > 0 && selectedTags.length === 0">No
+        posts match your search.</p>
+    <p x-show="searchQuery.trim().length === 0 && selectedTags.length > 0">No
+        posts match your selected tags.</p>
+    <p x-show="searchQuery.trim().length === 0 && selectedTags.length === 0">No
+        posts to show.</p>
+    <button
+        type="button"
+        @click="clearFilters()"
+        x-show="selectedTags.length > 0 || searchQuery.trim().length > 0 || sortMode !== 'newest'"
+        class="mt-4 px-4 py-2 rounded-full border border-gray-900 text-base hover:bg-gray-900 hover:text-white transition-colors"
+    >
+        Clear filters
+    </button>
+</div>
+```
+
+-   [ ] **Step 4: Build and lint**
+
+```
+npx gulp build
+npm run test
+```
+
+-   [ ] **Step 5: Manually verify in browser**
+
+Reload `http://localhost:2368/events/`.
+
+1. Toolbar shows search input (left, full-width) and sort dropdown (right).
+2. Type a query — results live-narrow after ~250ms; "Searching…" appears briefly.
+3. Combine with a tag chip — narrows further (intersection).
+4. Clear search — full set returns.
+5. Type a nonsense query like "asdfqwerzxcv" — empty state shows "No posts match your search." with Clear filters button.
+6. Click Clear filters — search input empties, chips deselect, sort returns to Newest first.
+7. Press Esc inside the search input — clears the input and refocuses it.
+8. Reload `?q=banking&sort=oldest&tags=hash-insights` — all three apply correctly on initial paint.
+9. (Mobile) Resize viewport to 375px — toolbar wraps: search above, sort below. Both still functional.
+10. (Error path) DevTools → Network → block `typesense.advisory.sg`. Type a search. Red error banner appears: "Search temporarily unavailable…". Chips and sort still work. Unblock and clear search to dismiss banner.
+
+Same checks on `/interviews/`.
+
+-   [ ] **Step 6: Commit**
+
+```
+git add partials/post-filter-list.hbs
+git commit -m "feat(search): add search input, indicator, banner, and empty-state adaptation"
+```
+
+---
+
+## Task 9: End-to-end manual verification matrix
+
+**Files:** none (verification only)
+
+A final pass against the spec's testing checklist (section 12 of the spec). No code changes. Catch anything missed before handing back to the user.
+
+-   [ ] **Step 1: Run the full matrix on `/events/`**
+
+Walk through every scenario in `docs/superpowers/specs/2026-05-06-search-sort-fullload-design.md` § "Testing and verification":
+
+1. ✅ Page loads → toolbar visible, chips visible, full event-post count present in DOM (`document.querySelectorAll('.filter-card-wrapper').length` matches expected).
+2. ✅ Type "stoic" → live narrow, count updates, URL gets `?q=stoic`.
+3. ✅ Click an interviews-related chip + search → AND-narrow.
+4. ✅ Change sort to "Title A→Z" → cards visually reorder. URL has `sort=az`.
+5. ✅ Refresh `/events/?q=banking&tags=hash-insights&sort=oldest` → all three pre-applied correctly on first paint.
+6. ✅ Block Typesense host → banner appears on next search; chips and sort still work.
+7. ✅ Type "x" (one char) → no Typesense request fires (verify in Network panel). Type "xy" → request fires.
+8. ✅ Type fast (multiple chars rapidly) → in-flight requests get cancelled (`status: cancelled` in Network panel).
+9. ✅ Disable JavaScript in DevTools → all posts visible in static grid; no toolbar; no chip UI.
+10. ✅ Mobile viewport (375px) → toolbar wraps to two rows.
+11. ✅ Tab through controls with keyboard. Tab order: search → sort → first chip → other chips → first card → load-more (if visible).
+12. ✅ Esc inside search input clears + refocuses.
+13. ✅ Clear filters button (in chip row AND in empty state) clears all four dimensions: tags, search, sort.
+
+-   [ ] **Step 2: Run the same matrix on `/interviews/`**
+
+Identical checks; substitute interview tag slugs.
+
+-   [ ] **Step 3: Confirm `/posts/` is unaffected**
+
+Load `http://localhost:2368/posts/`. Should show plain post grid, no toolbar, no chips, title "Posts". This template (`index.hbs`) shouldn't have changed.
+
+-   [ ] **Step 4: Confirm tag pages are unaffected**
+
+Load `http://localhost:2368/tag/<some-public-tag-slug>/`. Should show normal tag page, no filter UI. (Reads from `tag.hbs`, not touched.)
+
+-   [ ] **Step 5: Run `gscan` one final time**
+
+```
+npm run test
+```
+
+Should pass with no errors.
+
+-   [ ] **Step 6: Hand back to user**
+
+Report:
+
+-   Total commits added on this branch since the start of the plan.
+-   Any scenario from the matrix that didn't behave as expected.
+-   Any surprises or deviations from the spec that the implementer made.
+-   Suggested next step (typically: invoke `superpowers:finishing-a-development-branch` for PR/merge).
+
+---
+
+## Self-review notes (writer's check)
+
+**Spec coverage check:**
+
+-   Full-corpus load (Approach A, 20 blocks, 2000 ceiling) → Task 1.
+-   Sort options + UI + URL sync → Tasks 2, 3, 4.
+-   Typesense search wrapper → Task 5.
+-   `tagSlugs` plumbing for `filter_by` → Task 6.
+-   Search state, debounce, AbortController, error handling → Task 7.
+-   Search UI, searching indicator, error banner, empty-state copy, Clear-filters scope → Task 8.
+-   Accessibility (sr-only label, aria-controls, aria-live, role=alert, native select) → Task 8.
+-   All scenarios in spec § "Testing and verification" → Task 9.
+
+**Type/name consistency check:**
+
+-   `_readStateFromUrl` / `_writeStateToUrl` introduced in Task 3, extended in Task 7. Same names throughout.
+-   `searchSlugs` (component state) vs `searchSlugs` (imported function from `typesense-search.js`) — same name, different scope. Module export is namespaced via `import { searchSlugs } from './typesense-search.js'` and called as `searchSlugs(...)` (function call), distinct from `this.searchSlugs` (property access). No actual collision but worth knowing.
+-   `tagSlugs` parameter (string from partial) vs `tagSlugs` state (parsed array on the component) — same name, parsed in the component constructor. Confirmed in Task 3, Step 1 ("comma-separated string of tag slugs … Not consumed in Task 3" → parsed in `tagSlugs: (tagSlugs || '').split(',')...`).
+-   `setSearchQuery` (Task 7 step 6) is called from the input handler in Task 8 step 1 (`@input="setSearchQuery($event.target.value)"`). Names match.
+-   `data-published-at` (Task 2) → `inner.dataset.publishedAt` (Task 3, `_readCardsFromDom`). Camelcase auto-conversion is correct.

--- a/docs/superpowers/plans/2026-05-06-sort-filter.md
+++ b/docs/superpowers/plans/2026-05-06-sort-filter.md
@@ -1,0 +1,893 @@
+# Sort & Filter (Events / Interviews) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an in-place, multi-tag, client-side filter to `/events/` and `/interviews/`, with URL-synced state, "Load more" pagination, and a configurable OR/AND mode.
+
+**Architecture:** All matching posts are server-rendered into the page once via Ghost's `{{#get}}` helper. An Alpine.js component reads the post DOM, builds an available-tag list, watches a `selectedTags` array, and toggles `x-show` on each card to filter and paginate without re-fetching. Filter state syncs to `?tags=...` via `history.replaceState`.
+
+**Tech Stack:** Ghost theme (Handlebars partials + `routes.yaml`), Alpine.js (already a dep), Tailwind CSS (already a dep), webpack via gulp (already configured). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-05-06-sort-filter-design.md`
+
+## Working environment
+
+-   Local Ghost instance at `http://localhost:2368` with this theme installed.
+-   Build the theme one-shot: `npx gulp build` (compiles HBS, CSS, JS into `assets/built/`).
+-   Watch mode for active dev: `npm run dev` (runs `gulp` default — build + livereload + watch). Leave it running in a separate terminal.
+-   Theme linter: `npm run test` (runs `gscan .`). Must show no errors. CI form: `npm run test:ci`.
+-   Pre-commit hook (husky + pretty-quick) runs Prettier on staged files. Don't fight it — let it reformat.
+-   All tasks commit to the current branch (`filter-addition`).
+
+## File map
+
+**Created:**
+
+-   `interviews.hbs` — page template for `/interviews/` (mirror of `index.hbs` using the new partial).
+-   `partials/post-filter-list.hbs` — reusable filter UI + post grid + load-more.
+-   `assets/js/post-filter-list.js` — Alpine component definition.
+
+**Modified:**
+
+-   `partials/post-card.hbs` — add `data-tags` and `data-tag-names` to root `<article>`.
+-   `events.hbs` — swap tags-listing/foreach/pagination block for the new partial.
+-   `assets/js/main.js` — import the component file and register before `Alpine.start()`.
+-   `config/routes.yaml` — point `/interviews/` template at `interviews` instead of `index`.
+
+**Untouched:**
+
+-   `index.hbs` — still serves `/posts/` as a generic collection.
+-   `partials/tags-listing.hbs` — left intact.
+-   `tag.hbs` — left intact.
+
+---
+
+## Task 1: Add `data-tags` and `data-tag-names` to `post-card.hbs`
+
+**Files:**
+
+-   Modify: `partials/post-card.hbs:1`
+
+This card partial is shared across many pages (homepage, related posts, listings, tag pages). Adding two extra `data-*` attributes is harmless everywhere else and is what the new filter component reads.
+
+-   [ ] **Step 1: Edit the root `<article>` element**
+
+Change line 1 of `partials/post-card.hbs` from:
+
+```handlebars
+<article class="feed-card {{post_class}} rounded-lg shadow-2xl m-auto w-full max-w-2xl md:max-w-full lg:h-full hover:shadow-md hover:border-opacity-0 transform hover:-translate-y-1 transition-all duration-200">
+```
+
+to:
+
+```handlebars
+<article
+    class="feed-card {{post_class}} rounded-lg shadow-2xl m-auto w-full max-w-2xl md:max-w-full lg:h-full hover:shadow-md hover:border-opacity-0 transform hover:-translate-y-1 transition-all duration-200"
+    data-tags="{{#foreach tags visibility="public"}}{{slug}}{{#unless @last}},{{/unless}}{{/foreach}}"
+    data-tag-names="{{#foreach tags visibility="public"}}{{name}}{{#unless @last}},{{/unless}}{{/foreach}}">
+```
+
+The `visibility="public"` argument excludes Ghost's internal hash-prefixed routing tags (`#insights`, `#conversations`, etc.) so they don't surface as filter chips.
+
+-   [ ] **Step 2: Build and lint**
+
+Run:
+
+```
+npx gulp build
+npm run test
+```
+
+Both should complete with no errors.
+
+-   [ ] **Step 3: Manually verify in browser**
+
+With `npm run dev` running and Ghost serving the theme, load `http://localhost:2368/events/` in a browser. Open DevTools, inspect any `.feed-card` element, and confirm both `data-tags="..."` and `data-tag-names="..."` are present. They should contain only public tag slugs/names (no `hash-...` entries).
+
+-   [ ] **Step 4: Commit**
+
+```
+git add partials/post-card.hbs
+git commit -m "feat(post-card): expose public tags via data attributes"
+```
+
+---
+
+## Task 2: Add the Alpine component skeleton
+
+**Files:**
+
+-   Create: `assets/js/post-filter-list.js`
+-   Modify: `assets/js/main.js:1-12`
+
+Land the component file with all methods stubbed/empty so we can wire it into `main.js`, build, and verify Alpine doesn't error before adding logic.
+
+-   [ ] **Step 1: Create `assets/js/post-filter-list.js`**
+
+```javascript
+// Alpine component for client-side multi-tag filter, load-more, and URL sync.
+// Used by partials/post-filter-list.hbs on /events/ and /interviews/.
+//
+// Call site:
+//   <div x-data="postFilterList({ collection: 'events', mode: 'or' })" ...>
+export default function postFilterList({ collection, mode }) {
+    const PAGE_SIZE = 12;
+
+    return {
+        selectedTags: [],
+        visibleCount: PAGE_SIZE,
+        allCards: [],
+        availableTags: [],
+
+        init() {
+            this.allCards = this._readCardsFromDom();
+            this.availableTags = this._buildAvailableTags();
+            this.selectedTags = this._readTagsFromUrl();
+            this.$watch("selectedTags", () => {
+                this.visibleCount = PAGE_SIZE;
+                this._writeTagsToUrl();
+            });
+        },
+
+        // --- queries -----------------------------------------------------
+
+        matches(card) {
+            if (this.selectedTags.length === 0) return true;
+            if (mode === "and") {
+                return this.selectedTags.every((t) => card.tagSlugs.has(t));
+            }
+            return this.selectedTags.some((t) => card.tagSlugs.has(t));
+        },
+
+        filtered() {
+            return this.allCards.filter((c) => this.matches(c));
+        },
+
+        visible() {
+            return this.filtered().slice(0, this.visibleCount);
+        },
+
+        isVisible(el) {
+            return this.visible().some((c) => c.el === el);
+        },
+
+        unknownTags() {
+            const known = new Set(this.availableTags.map((t) => t.slug));
+            return this.selectedTags.filter((s) => !known.has(s));
+        },
+
+        hasMore() {
+            return this.filtered().length > this.visibleCount;
+        },
+
+        // --- actions -----------------------------------------------------
+
+        isSelected(slug) {
+            return this.selectedTags.includes(slug);
+        },
+
+        toggleTag(slug) {
+            if (this.isSelected(slug)) {
+                this.selectedTags = this.selectedTags.filter((s) => s !== slug);
+            } else {
+                this.selectedTags = [...this.selectedTags, slug];
+            }
+        },
+
+        loadMore() {
+            this.visibleCount += PAGE_SIZE;
+            // Move focus to the first newly-revealed card for keyboard users.
+            this.$nextTick(() => {
+                const newIndex = this.visibleCount - PAGE_SIZE;
+                const card = this.filtered()[newIndex];
+                if (card && card.el) card.el.focus();
+            });
+        },
+
+        clearFilters() {
+            this.selectedTags = [];
+        },
+
+        // --- internals ---------------------------------------------------
+
+        _readCardsFromDom() {
+            const root = this.$root || this.$el;
+            const cards = root.querySelectorAll("[data-tags]");
+            return Array.from(cards).map((el) => {
+                const slugs = (el.dataset.tags || "")
+                    .split(",")
+                    .map((s) => s.trim())
+                    .filter(Boolean);
+                return { el, tagSlugs: new Set(slugs) };
+            });
+        },
+
+        _buildAvailableTags() {
+            const root = this.$root || this.$el;
+            const cards = root.querySelectorAll("[data-tags]");
+            const map = new Map();
+            cards.forEach((el) => {
+                const slugs = (el.dataset.tags || "").split(",");
+                const names = (el.dataset.tagNames || "").split(",");
+                slugs.forEach((slug, i) => {
+                    const s = slug.trim();
+                    if (!s) return;
+                    if (!map.has(s)) {
+                        map.set(s, { slug: s, name: (names[i] || s).trim() });
+                    }
+                });
+            });
+            return Array.from(map.values()).sort((a, b) =>
+                a.name.localeCompare(b.name),
+            );
+        },
+
+        _readTagsFromUrl() {
+            const params = new URLSearchParams(window.location.search);
+            const raw = params.get("tags") || "";
+            return raw
+                .split(",")
+                .map((s) => s.trim())
+                .filter(Boolean);
+        },
+
+        _writeTagsToUrl() {
+            const params = new URLSearchParams(window.location.search);
+            if (this.selectedTags.length) {
+                params.set("tags", this.selectedTags.join(","));
+            } else {
+                params.delete("tags");
+            }
+            const qs = params.toString();
+            const newUrl = qs
+                ? `${window.location.pathname}?${qs}`
+                : window.location.pathname;
+            window.history.replaceState(null, "", newUrl);
+        },
+    };
+}
+```
+
+-   [ ] **Step 2: Wire it into `main.js`**
+
+Modify the top of `assets/js/main.js`. Find:
+
+```javascript
+import "./jquery-global.js";
+
+import InfiniteScroll from "infinite-scroll";
+import fitvids from "fitvids";
+import "lazysizes";
+
+import Glide from "@glidejs/glide";
+import Alpine from "alpinejs";
+import "flowbite";
+
+window.Alpine = Alpine;
+Alpine.start();
+```
+
+Replace with:
+
+```javascript
+import "./jquery-global.js";
+
+import InfiniteScroll from "infinite-scroll";
+import fitvids from "fitvids";
+import "lazysizes";
+
+import Glide from "@glidejs/glide";
+import Alpine from "alpinejs";
+import "flowbite";
+
+import postFilterList from "./post-filter-list.js";
+
+window.Alpine = Alpine;
+Alpine.data("postFilterList", postFilterList);
+Alpine.start();
+```
+
+Order matters: `Alpine.data(...)` must run before `Alpine.start()`.
+
+-   [ ] **Step 3: Build**
+
+Run:
+
+```
+npx gulp build
+```
+
+Should complete with no webpack errors.
+
+-   [ ] **Step 4: Verify Alpine still works**
+
+Reload `http://localhost:2368/events/` in a browser. Open DevTools console — there should be no Alpine errors. Other Alpine-driven widgets on the page (if any — flowbite uses Alpine) should still work normally.
+
+-   [ ] **Step 5: Commit**
+
+```
+git add assets/js/post-filter-list.js assets/js/main.js
+git commit -m "feat(js): add postFilterList Alpine component"
+```
+
+---
+
+## Task 3: Create `partials/post-filter-list.hbs` and use it on `/events/`
+
+**Files:**
+
+-   Create: `partials/post-filter-list.hbs`
+-   Modify: `events.hbs` (entire body)
+
+Render the partial with full markup but no chip interaction yet — just the post grid via `{{#get}}`. This is the first user-visible step: `/events/` should look almost identical to before, with a chip row added above and a "Load more" button below.
+
+-   [ ] **Step 1: Create the partial**
+
+Create `partials/post-filter-list.hbs`:
+
+```handlebars
+{{!-- Reusable filter UI + post grid + load-more.
+     Parameters:
+       collection — string label (used as DOM id namespace)
+       filter     — Ghost filter string passed to {{#get "posts"}}
+       mode       — "or" (default) or "and" --}}
+
+<div
+    id="post-filter-{{collection}}"
+    x-data="postFilterList({ collection: '{{collection}}', mode: '{{mode}}' })"
+    x-cloak
+    class="post-filter-list">
+
+    {{!-- Filter chips (only visible if there are tags to filter by) --}}
+    <div
+        class="filter-chips container m-auto flex flex-wrap gap-2 mb-6 px-4"
+        x-show="availableTags.length > 0">
+        <template x-for="tag in availableTags" :key="tag.slug">
+            <button
+                type="button"
+                role="checkbox"
+                :aria-checked="isSelected(tag.slug)"
+                @click="toggleTag(tag.slug)"
+                :class="isSelected(tag.slug)
+                    ? 'bg-brand-light text-gray-900 border-gray-900'
+                    : 'bg-white text-gray-700 border-gray-300'"
+                class="px-4 py-2 rounded-full border text-base hover:border-gray-900 transition-colors">
+                <span x-text="tag.name"></span>
+            </button>
+        </template>
+        <button
+            type="button"
+            @click="clearFilters()"
+            x-show="selectedTags.length > 0"
+            class="px-4 py-2 rounded-full text-base text-gray-700 underline hover:text-gray-900">
+            Clear filters
+        </button>
+    </div>
+
+    {{!-- Live result count for screen readers --}}
+    <div role="status" aria-live="polite" class="container m-auto px-4 mb-4 text-lg text-gray-700">
+        <span x-text="`Showing ${visible().length} of ${filtered().length}`"></span>
+    </div>
+
+    {{!-- Unknown-tags banner (URL referenced tags not on this page) --}}
+    <div
+        x-show="unknownTags().length > 0"
+        class="container m-auto px-4 mb-4 p-3 rounded border bg-amber-50 border-amber-200 text-amber-900 text-base">
+        The following tags don't exist on this page:
+        <template x-for="(slug, i) in unknownTags()" :key="slug">
+            <span><code x-text="slug"></code><span x-show="i < unknownTags().length - 1">, </span></span>
+        </template>
+    </div>
+
+    {{!-- Empty state --}}
+    <div
+        x-show="filtered().length === 0"
+        class="container m-auto px-4 py-12 text-center text-xl text-gray-700">
+        <p>No posts match your selected tags.</p>
+    </div>
+
+    {{!-- Server-rendered post grid. Cards stay in DOM; Alpine toggles x-show. --}}
+    <div class="post-feed container grid grid-cols-1 lg:grid-cols-3 gap-x-20 gap-y-10 m-auto">
+        <!-- djlint:off -->
+        {{#get "posts" limit="1000" filter=filter include="tags" order="published_at desc" as |posts|}}
+        <!-- djlint:on -->
+            {{#foreach posts}}
+                <div x-show="isVisible($el.querySelector('[data-tags]'))" class="filter-card-wrapper">
+                    {{> "post-card"}}
+                </div>
+            {{/foreach}}
+        {{/get}}
+    </div>
+
+    {{!-- Load more button --}}
+    <div class="container m-auto px-4 my-8 text-center" x-show="hasMore()">
+        <button
+            type="button"
+            @click="loadMore()"
+            class="px-6 py-3 rounded-full border border-gray-900 text-lg font-bold hover:bg-gray-900 hover:text-white transition-colors">
+            Load more
+        </button>
+    </div>
+</div>
+
+<style>
+    [x-cloak] { display: none !important; }
+</style>
+```
+
+Note on `isVisible`: each card is wrapped in a `<div class="filter-card-wrapper">`, and the wrapper's `x-show` calls `isVisible()` against the inner `[data-tags]` element (the `<article>` produced by `post-card.hbs`).
+
+-   [ ] **Step 2: Update `events.hbs` to use the partial**
+
+Replace the entire contents of `events.hbs` with:
+
+```handlebars
+{{!< default}}
+
+{{#contentFor "title"}}Events{{/contentFor}}
+
+<div class="content-area">
+    <main class="site-main">
+        <header class="single-header kg-canvas">
+            <h1 class="single-title">Events</h1>
+        </header>
+        {{> post-filter-list collection="events" filter="tag:hash-insights" mode="or"}}
+    </main>
+</div>
+```
+
+-   [ ] **Step 3: Build and lint**
+
+Run:
+
+```
+npx gulp build
+npm run test
+```
+
+Both should complete with no errors.
+
+-   [ ] **Step 4: Manual verification at `localhost:2368/events/`**
+
+In the browser:
+
+-   The page should render with a row of pill chips at the top (one per tag found across event posts), a "Showing X of Y" line, and the same post grid as before. A "Load more" button appears below if there are more than 12 posts.
+-   Click a chip — nothing should happen yet. Why: the `x-show` on each card uses `isVisible($el.querySelector('[data-tags]'))`, which depends on `visible()`, which depends on `selectedTags` and `visibleCount`. **It will work** as soon as `selectedTags` changes via `toggleTag` — but visually verify that the chips render and that the initial 12-card limit is enforced.
+-   Verify in DevTools: every `.feed-card` `<article>` is wrapped in a `.filter-card-wrapper`, and only the first 12 wrappers are visible (the rest have `display: none` from Alpine's `x-show`).
+-   Click a chip — the page should now filter to posts with that tag. Click again to deselect.
+-   Click two chips — posts with **either** tag should show (OR mode default).
+-   The URL should update to `?tags=...` as you click.
+
+-   [ ] **Step 5: Commit**
+
+```
+git add partials/post-filter-list.hbs events.hbs
+git commit -m "feat(events): add multi-tag filter and load-more"
+```
+
+---
+
+## Task 4: Verify URL sync end-to-end
+
+**Files:** None modified. This is a manual verification gate.
+
+The Alpine component already implements URL sync (Task 2) and the partial is wired up (Task 3). This task confirms the end-to-end behavior matches the spec.
+
+-   [ ] **Step 1: Filter from a clean URL**
+
+-   Visit `http://localhost:2368/events/` (no query).
+-   Click two chips. URL should become `http://localhost:2368/events/?tags=slug-1,slug-2` (with whatever slugs you picked).
+-   Click one chip again to deselect. URL should drop that slug.
+-   Click "Clear filters". URL should drop `?tags=` entirely (back to plain `/events/`).
+
+-   [ ] **Step 2: Land on a pre-filtered URL**
+
+-   Manually navigate to `http://localhost:2368/events/?tags=<a-real-slug>` in the address bar.
+-   The page should load with that chip already selected and posts filtered.
+
+-   [ ] **Step 3: Land on an unknown-tag URL**
+
+-   Navigate to `http://localhost:2368/events/?tags=marine-biology-no-such-tag`.
+-   Expected: amber banner listing `marine-biology-no-such-tag`, empty post grid, "Showing 0 of 0", and "Clear filters" button visible.
+-   Click "Clear filters". Banner disappears, all posts return.
+
+-   [ ] **Step 4: Land on a mixed URL (one valid, one unknown)**
+
+-   Navigate to `http://localhost:2368/events/?tags=<a-real-slug>,nonexistent-slug`.
+-   Expected: real-slug chip selected, posts filtered to that real tag, banner showing only `nonexistent-slug`.
+
+-   [ ] **Step 5: Land on a malformed URL**
+
+-   Navigate to `http://localhost:2368/events/?tags=,,,`.
+-   Expected: no error, no filter applied, no banner (the empties are stripped).
+
+-   [ ] **Step 6: Browser back/forward**
+
+-   From `/events/`, click a chip → URL changes via `replaceState`.
+-   Press browser Back. You should leave `/events/` entirely (not bounce between filter states), because we used `replaceState` not `pushState`. This is the intended behavior per the spec.
+
+-   [ ] **Step 7: Commit (no code change — just a marker)**
+
+If everything passes, no code changes are needed. Skip the commit. If something fails, debug and re-run this task before continuing.
+
+---
+
+## Task 5: Verify load-more behavior
+
+**Files:** None modified. Another manual verification gate.
+
+-   [ ] **Step 1: Initial state**
+
+-   Visit `http://localhost:2368/events/`.
+-   Verify exactly 12 posts are visible (or all of them if the collection has fewer than 12).
+-   "Load more" button appears only if there are more than 12 matching posts.
+
+-   [ ] **Step 2: Click "Load more"**
+
+-   Click the button.
+-   12 more posts become visible (or all remaining, whichever is smaller).
+-   Counter updates: "Showing 24 of N" (or similar).
+-   Button hides when all matches are visible.
+
+-   [ ] **Step 3: Filter resets count**
+
+-   After loading more (e.g. 24 visible of 30), click any chip.
+-   Visible count should reset to 12 (of however many match the filter).
+-   The `visibleCount = PAGE_SIZE` line in the `$watch('selectedTags')` callback drives this.
+
+-   [ ] **Step 4: Focus moves on load-more**
+
+-   Tab through the page using the keyboard until focus is on "Load more".
+-   Press Enter or Space.
+-   Focus should jump to the first newly-revealed card (the 13th overall, or the 13th match if a filter is applied). Verify by pressing Tab again — focus should move from card 13 onward, not from the start of the page.
+
+-   [ ] **Step 5: Commit (no code change)**
+
+If everything passes, skip the commit. If focus management or the count reset isn't working, re-read Task 2 step 1 (component code) and fix.
+
+---
+
+## Task 6: Add and manually verify the AND mode
+
+**Files:**
+
+-   Modify: `events.hbs` (one-character change for the duration of this task; will be reverted)
+
+The component already handles `mode === 'and'` (Task 2 step 1). This task verifies it works end-to-end.
+
+-   [ ] **Step 1: Switch the mode in `events.hbs`**
+
+Change:
+
+```handlebars
+{{> post-filter-list collection="events" filter="tag:hash-insights" mode="or"}}
+```
+
+to:
+
+```handlebars
+{{> post-filter-list collection="events" filter="tag:hash-insights" mode="and"}}
+```
+
+-   [ ] **Step 2: Build**
+
+```
+npx gulp build
+```
+
+-   [ ] **Step 3: Manual verification**
+
+-   Visit `http://localhost:2368/events/`.
+-   Click one chip. Same posts as OR mode (single-tag selection behaves identically in both modes).
+-   Click a second chip. Now only posts that have **both** selected tags should show. If no post has both, you should see the empty state ("No posts match your selected tags").
+-   Deselect one chip. Filter relaxes to whatever the remaining chip alone matches.
+
+-   [ ] **Step 4: Revert to OR**
+
+Change the `mode="and"` back to `mode="or"`. Build again.
+
+-   [ ] **Step 5: Commit (no code change since we reverted)**
+
+If verification passed, skip. The `mode` parameter is now production-ready; production runs OR.
+
+---
+
+## Task 7: Add `interviews.hbs` and update `routes.yaml`
+
+**Files:**
+
+-   Create: `interviews.hbs`
+-   Modify: `config/routes.yaml:10-13`
+
+Now repeat the events setup for the interviews collection. Create a dedicated `interviews.hbs` template (so the filter UI does not bleed onto generic `/posts/` or other pages that share `index.hbs`).
+
+-   [ ] **Step 1: Create `interviews.hbs`**
+
+```handlebars
+{{!< default}}
+
+{{#contentFor "title"}}Interviews{{/contentFor}}
+
+<div class="content-area">
+    <main class="site-main">
+        <header class="single-header kg-canvas">
+            <h1 class="single-title">Interviews</h1>
+        </header>
+        {{> post-filter-list
+            collection="interviews"
+            filter="tag:[hash-conversations,hash-reflections]"
+            mode="or"}}
+    </main>
+</div>
+```
+
+-   [ ] **Step 2: Update `config/routes.yaml`**
+
+Find:
+
+```yaml
+/interviews/:
+    permalink: /{year}/{month}/{day}/{slug}/
+    template: index
+    filter: tag:[hash-conversations,hash-reflections]
+```
+
+Change `template: index` to `template: interviews`:
+
+```yaml
+/interviews/:
+    permalink: /{year}/{month}/{day}/{slug}/
+    template: interviews
+    filter: tag:[hash-conversations,hash-reflections]
+```
+
+-   [ ] **Step 3: Reload routes in Ghost**
+
+Ghost loads `routes.yaml` from the active theme. If it doesn't pick up the change automatically, in the Ghost admin (`http://localhost:2368/ghost/`) go to **Settings → Labs → Routes**, download/upload the routes file, or restart Ghost. (Locally, restarting Ghost is the simplest reliable option.)
+
+-   [ ] **Step 4: Build and lint**
+
+```
+npx gulp build
+npm run test
+```
+
+-   [ ] **Step 5: Manual verification**
+
+-   Visit `http://localhost:2368/interviews/`. Verify chips appear, filtering works, load-more works, URL sync works (same scenarios as Tasks 4–5 but on interviews).
+-   Visit `http://localhost:2368/posts/` (the generic collection that still uses `index.hbs`). Verify **no filter UI** appears here.
+-   Visit `http://localhost:2368/tag/<some-public-tag>/`. Verify **no filter UI** appears here either (still uses `tag.hbs`).
+
+-   [ ] **Step 6: Commit**
+
+```
+git add interviews.hbs config/routes.yaml
+git commit -m "feat(interviews): add filter using shared partial"
+```
+
+---
+
+## Task 8: Add canonical link to event/interview templates
+
+**Files:**
+
+-   Modify: `events.hbs`, `interviews.hbs` (only if `{{ghost_head}}` does not already emit a canonical)
+
+Filtered URLs (`?tags=...`) are content variants of the canonical pages. Canonical link tags tell search engines to dedupe.
+
+-   [ ] **Step 1: Check what `{{ghost_head}}` emits**
+
+Visit `http://localhost:2368/events/?tags=test` and view source. Look in `<head>` for an existing `<link rel="canonical" ...>` tag.
+
+-   If a canonical tag is present and points to `/events/` (without `?tags=`): you're done. Skip to Step 3.
+-   If no canonical, or it points to the filtered URL: proceed to Step 2.
+
+-   [ ] **Step 2: Add canonical to both templates**
+
+Add this inside the `{{#contentFor "title"}}...{{/contentFor}}` blocks, or as a separate `contentFor "head"` block if `default.hbs` supports it. If it doesn't, add directly inside the body of the template — browsers and crawlers also accept it inside `<body>` though `<head>` is preferred.
+
+In `events.hbs`, after the `{{#contentFor "title"}}` line:
+
+```handlebars
+{{#contentFor "head"}}
+    <link rel="canonical" href="{{@site.url}}/events/" />
+{{/contentFor}}
+```
+
+In `interviews.hbs`, similarly:
+
+```handlebars
+{{#contentFor "head"}}
+    <link rel="canonical" href="{{@site.url}}/interviews/" />
+{{/contentFor}}
+```
+
+Then check `default.hbs` — if it does not have `{{{block "head"}}}` inside `<head>`, add it just before `{{ghost_head}}`:
+
+```handlebars
+{{{block "head"}}}
+{{ghost_head}}
+```
+
+-   [ ] **Step 3: Build and verify**
+
+```
+npx gulp build
+```
+
+Visit `http://localhost:2368/events/?tags=test` and view source. Confirm a single canonical pointing to `/events/` (not `/events/?tags=test`).
+
+-   [ ] **Step 4: Commit (only if you made changes)**
+
+```
+git add events.hbs interviews.hbs default.hbs
+git commit -m "seo: canonicalize filtered events/interviews URLs"
+```
+
+---
+
+## Task 9: Accessibility manual verification
+
+**Files:** None modified, unless issues are found.
+
+The component already includes `role="checkbox"`, `aria-checked`, `aria-live`, and focus management. This task spot-checks them.
+
+-   [ ] **Step 1: Keyboard tab order**
+
+-   Visit `http://localhost:2368/events/`.
+-   From the address bar, press Tab until focus enters the chip row.
+-   Verify each chip is reachable and visible focus indicator appears.
+-   Press Space on a chip — it should toggle, posts should filter, screen reader (if available) should announce the new "Showing X of Y" count via the `aria-live` region.
+
+-   [ ] **Step 2: Screen reader spot check (optional, if available)**
+
+-   Enable VoiceOver (macOS), NVDA (Windows), or Orca (Linux).
+-   Tab to a chip — should announce "checkbox, not checked" (or similar).
+-   Activate it — should announce the updated result count.
+
+-   [ ] **Step 3: Contrast and visual focus**
+
+-   Tab through chips. Each focused chip should have a visible focus ring (browser default is fine; Tailwind doesn't strip it unless explicitly told to).
+-   Selected vs unselected chips should differ in **more than just color** (we use background + border change + a checkmark concept via `aria-checked` styling). If selected chips look indistinguishable to the eye, add a checkmark icon: edit the chip `<button>` in `post-filter-list.hbs` to include an `<svg>` shown only when `isSelected(tag.slug)`.
+
+-   [ ] **Step 4: Commit (only if you made styling changes)**
+
+If you added the checkmark icon or fixed contrast:
+
+```
+git add partials/post-filter-list.hbs
+git commit -m "a11y(filter): improve selected-chip visual distinction"
+```
+
+---
+
+## Task 10: JS-disabled graceful degradation check
+
+**Files:** None modified.
+
+-   [ ] **Step 1: Disable JavaScript**
+
+In Chrome DevTools: open Settings (F1) → Debugger → "Disable JavaScript". Or use the Command Menu (Ctrl/Cmd+Shift+P) → "Disable JavaScript".
+
+-   [ ] **Step 2: Reload `/events/`**
+
+-   Posts should still be visible (server-rendered).
+-   Filter chips might be visible but won't respond — acceptable.
+-   The `[x-cloak]` style hides the entire `post-filter-list` div until Alpine initializes, which means with JS disabled, **the whole filter region (chips + grid) is hidden**. This is a bug for the no-JS path.
+
+-   [ ] **Step 3: Fix the cloak-hides-everything issue**
+
+Move `[x-cloak]` so it hides only the chip row and counter — not the post grid. Edit `partials/post-filter-list.hbs`:
+
+-   Remove `x-cloak` from the root `<div>`.
+-   Add `x-cloak` to the `.filter-chips` div, the `aria-live` counter div, the unknown-tags banner, the empty-state div, and the load-more div — but NOT the `.post-feed` grid.
+
+After change, the no-JS user sees: header, post grid (all matching posts, no pagination), no filter UI. Acceptable graceful degradation.
+
+-   [ ] **Step 4: Re-enable JS, build, and verify**
+
+Re-enable JS in DevTools. Run `npx gulp build`. Reload `/events/`. Filter UI should work as before.
+
+-   [ ] **Step 5: Disable JS again, reload — confirm graceful degradation**
+
+Posts should be visible without filter UI. Re-enable JS afterward.
+
+-   [ ] **Step 6: Commit**
+
+```
+git add partials/post-filter-list.hbs
+git commit -m "fix(filter): degrade gracefully when JS is disabled"
+```
+
+---
+
+## Task 11: Mobile / narrow viewport check
+
+**Files:** None modified, unless issues are found.
+
+-   [ ] **Step 1: Test responsive layout**
+
+In Chrome DevTools, toggle device toolbar (Ctrl/Cmd+Shift+M). Set viewport to 375px wide (iPhone SE).
+
+-   [ ] **Step 2: Verify chip row wraps**
+
+-   Chips should wrap to multiple rows (Tailwind `flex-wrap` already in the partial markup).
+-   Counter and load-more button stack centered.
+-   No horizontal scroll on the page.
+
+-   [ ] **Step 3: Verify chips are tap-friendly**
+
+-   Each chip should be at least 44x44 pixels tap target. The current `px-4 py-2 text-base` should produce ~40px height. If it's too small, bump padding to `px-4 py-3`.
+
+-   [ ] **Step 4: Commit (only if you made styling changes)**
+
+```
+git add partials/post-filter-list.hbs
+git commit -m "style(filter): adjust mobile chip sizing"
+```
+
+---
+
+## Task 12: Final regression sweep and PR-ready commit
+
+**Files:** None modified. End-to-end verification.
+
+-   [ ] **Step 1: Build clean**
+
+```
+npx gulp build
+npm run test
+```
+
+Both must pass with no errors.
+
+-   [ ] **Step 2: Run through every spec scenario**
+
+Tick through every row in the spec's "Testing" table:
+
+| #   | Page                        | Action                 | Expected                                 |
+| --- | --------------------------- | ---------------------- | ---------------------------------------- |
+| 1   | /events/                    | No filter              | All event posts visible (12 + load more) |
+| 2   | /events/                    | Single chip            | Filter to that tag                       |
+| 3   | /events/                    | Two chips (OR)         | Posts matching either                    |
+| 4   | /events/                    | Deselect chip          | Filter relaxes                           |
+| 5   | /events/                    | Clear filters          | All chips off, URL clean                 |
+| 6   | /events/                    | Load more              | Next 12 visible                          |
+| 7   | /events/                    | Filter after load-more | Count resets to 12                       |
+| 8   | /events/?tags=valid         | URL preload            | Pre-filtered                             |
+| 9   | /events/?tags=invalid       | URL preload            | Empty + amber banner                     |
+| 10  | /events/?tags=valid,invalid | URL preload            | Filtered + banner for invalid            |
+| 11  | /events/?tags=,,,           | URL preload            | No filter, no error                      |
+| 12  | /interviews/                | All scenarios 1–11     | Same behavior                            |
+| 13  | /posts/                     | Visit                  | No filter UI                             |
+| 14  | /tag/&lt;slug&gt;/          | Visit                  | No filter UI                             |
+| 15  | /events/                    | JS disabled            | Posts visible, no filter UI              |
+| 16  | /events/                    | Keyboard tab/space     | Chips toggle, aria-live announces        |
+| 17  | /events/                    | Mobile viewport        | Chips wrap, no horizontal scroll         |
+| 18  | /events/                    | mode="and" temporarily | Two chips → AND match                    |
+
+-   [ ] **Step 3: Verify git log is clean**
+
+```
+git log --oneline filter-addition ^main
+```
+
+You should see roughly 5–8 small, focused commits since branching from main. If any commits are noise (e.g. typo fixes), consider squashing them into the relevant feature commit. Do not force-push to a shared branch without confirming with the user.
+
+-   [ ] **Step 4: Hand off**
+
+The branch is ready for code review / PR. Do not open the PR automatically — let the user do that, or ask them whether to.
+
+---
+
+## Out of scope (not in this plan)
+
+These are explicitly **not** implemented here. They are listed so a reviewer doesn't ask "where's X":
+
+-   Sort dropdown (date is fixed newest-first per spec).
+-   Author / year filters.
+-   Filter on `/posts/`, tag pages, or author pages.
+-   Analytics events on filter changes.
+-   Unit tests for the Alpine component (no test framework in this repo).
+-   Server-side filter routing variants in `routes.yaml`.
+-   Suggested-articles improvements (Feature 2 — separate spec to come).

--- a/docs/superpowers/specs/2026-05-06-features-overview.md
+++ b/docs/superpowers/specs/2026-05-06-features-overview.md
@@ -1,0 +1,40 @@
+# Features Overview — 2026-05-06
+
+Two independent features captured during brainstorming. Each will get its own
+full design doc and implementation plan. This file is a high-level index so
+neither feature is lost; it is **not** a spec.
+
+## Feature 1 — Sort & filter on Interviews and Events pages (PRIORITY)
+
+**Pages affected:** `index.hbs` (Interviews), `events.hbs` (Events).
+
+**Current state:**
+
+-   Server-rendered Ghost collections defined in `config/routes.yaml`:
+    -   Events filters by internal tag `#insights`
+    -   Interviews filters by internal tags `#conversations` or `#reflections`
+-   `partials/tags-listing.hbs` shows a tag dropdown, but selecting a tag
+    navigates to `/tag/<slug>` instead of filtering in place
+-   No sort control exists
+
+**Goal:** Let users sort and filter the post listing in place on each page,
+without leaving the listing context.
+
+**Status:** In active design — see `2026-05-06-sort-filter-design.md` (to be
+written).
+
+## Feature 2 — More targeted suggested articles on post pages
+
+**Files affected:** `partials/related.hbs`, `post.hbs`.
+
+**Current state:** `partials/related.hbs` runs
+`{{#get "posts" limit="3" filter="tags:[{{post.tags}}]+id:-{{post.id}}"}}`.
+The `tags:[a,b,c]` filter is OR (not AND), so any post sharing a single tag
+matches; results are ordered by default (published date desc). Not really
+targeted.
+
+**Goal:** Surface related posts that are actually closely related — primary
+tag overlap, author match, recency — instead of any-tag matches.
+
+**Status:** Deferred. Will be brainstormed in a separate session after
+Feature 1 ships.

--- a/docs/superpowers/specs/2026-05-06-search-sort-fullload-design.md
+++ b/docs/superpowers/specs/2026-05-06-search-sort-fullload-design.md
@@ -1,0 +1,277 @@
+# Search, Sort, and Full-corpus Load — Design
+
+**Date:** 2026-05-06
+**Status:** Drafted, awaiting user review
+**Related:** `2026-05-06-sort-filter-design.md` (the prior shipped feature this extends)
+
+## Goal
+
+Extend the existing tag-filter UI on `/events/` and `/interviews/` with three additions:
+
+1. **Search** — a live, typo-tolerant text search across the full post corpus, backed by Typesense.
+2. **Sort** — a dropdown letting readers reorder by date or title.
+3. **Full-corpus load** — fix the bug where `{{#get "posts" limit="all"}}` silently caps at 100, so all events/interviews are reachable via filter and sort.
+
+All three integrate with the existing chip filter without disturbing it.
+
+## Non-goals
+
+-   Migrating chip filtering off client-side (chips already work on a few hundred posts; keep as is).
+-   Replacing the chip filter UI with a Typesense-backed widget (e.g. MagicPages' drop-in widget).
+-   Search highlighting in result cards.
+-   Search history, suggestions, autocomplete.
+-   Analytics on search terms.
+-   Maintaining the Typesense → Ghost sync mechanism. That is out of scope and handled separately.
+-   A relevance-ranked sort option (sort uses simple date/title only; Typesense's own ranking determines which slugs are _included_, not the visual order, which still respects user's sort choice).
+-   Author or date-range filters.
+
+## Decisions and rationale
+
+| Decision                   | Choice                                                                                              | Rationale                                                                                                                                                                                                                                                                                                                                                                                               |
+| -------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Full-corpus load           | Approach A: 20 stacked `{{#get limit=100 page=N}}` blocks via sub-partial. Hard ceiling 2000 posts. | At 287 posts today, the Content API plumbing of approach C is overkill. 20 blocks gives years of runway. Stays fully SSR — no API key, no JS fetch loop, no fetch-error states.                                                                                                                                                                                                                         |
+| Search backend             | Typesense, REST API direct from browser                                                             | User has a populated Typesense instance ready (`typesense.advisory.sg`, collection `ghost`). Gives fuzzy matching, full-corpus scope, and no in-DOM payload bloat. We skip MagicPages' UI widget so we keep our own styled search input.                                                                                                                                                                |
+| Search field weighting     | `query_by=title,excerpt,plaintext` weighted `4,2,1`                                                 | Title hits matter most; excerpt is a strong signal; body matches are weakest. Standard search UX.                                                                                                                                                                                                                                                                                                       |
+| Search → cards mapping     | Typesense returns slugs only (`include_fields=slug`); JS overlays visibility on SSR cards.          | Keeps response payload tiny (~50 bytes per hit). Card data already in DOM from SSR — no need to round-trip the heavy fields.                                                                                                                                                                                                                                                                            |
+| Search constraint          | `filter_by=tags.slug:[…]` matching the page's tag set.                                              | The Typesense collection holds _all_ Ghost posts, not just events or interviews. Without this constraint, a search on `/events/` returns slugs for posts that aren't on the page → silent drops. The constraint is sourced from `routes.yaml` and passed as a new partial parameter.                                                                                                                    |
+| Search input UX            | Live, debounced 250ms.                                                                              | Live matches the chip behaviour. 250ms (vs 150ms for in-DOM) accounts for network latency.                                                                                                                                                                                                                                                                                                              |
+| Search short-circuit       | Skip Typesense call when query length < 2 chars.                                                    | Single-character queries waste bandwidth and produce noise.                                                                                                                                                                                                                                                                                                                                             |
+| Stale-request handling     | `AbortController` cancels in-flight requests when a newer query starts.                             | Prevents older response from clobbering newer state.                                                                                                                                                                                                                                                                                                                                                    |
+| Search × chips combination | AND (intersect)                                                                                     | What users expect — chip narrows category, search narrows within it.                                                                                                                                                                                                                                                                                                                                    |
+| Sort options               | Newest (default) / Oldest / Title A→Z / Title Z→A                                                   | Covers the common needs without a relevance option (see non-goals).                                                                                                                                                                                                                                                                                                                                     |
+| Sort implementation        | Client-side reorder of `<div class="filter-card-wrapper">` elements via `appendChild` to grid       | Sort changes only fire on dropdown change (rare). O(n log n) with n ≤ 2000 is fine. No CSS `order:` because card layout is grid. Date sort reads `data-published-at` (ISO string, lexically sortable). Title sort uses `String.prototype.localeCompare` on `data-title`. Hidden cards (`x-show=false`) reorder along with visible ones; CSS Grid lays out only the visible ones in their new DOM order. |
+| URL state                  | `?tags=…&q=…&sort=…`                                                                                | All three filterable dimensions persist for sharing/refresh. Defaults (`sort=newest`, empty `q`) omitted.                                                                                                                                                                                                                                                                                               |
+| Toolbar layout             | Single row above chips: search input flex-1 left, sort `<select>` right. Wraps on mobile.           | Compact; consistent with existing chip row directly below.                                                                                                                                                                                                                                                                                                                                              |
+| Typesense API key handling | Hardcoded constants in `assets/js/typesense-search.js`                                              | The key (`LWQ1uy…`) is a _search-only_ Typesense key — Typesense's analogue of Ghost's Content API key, designed for client-side embedding and read-only scope. Committing it to source is intentional. Future migration to env-var injection if per-env keys become needed.                                                                                                                            |
+
+## Architecture
+
+```
+routes.yaml ──> events.hbs / interviews.hbs
+                       │
+                       │  passes: collection, filter, tagSlugs, mode
+                       ↓
+             partials/post-filter-list.hbs
+                       │
+                       ├── toolbar:    search input + sort <select> + searching indicator + error banner
+                       ├── chips:      Alpine x-for over availableTags  (unchanged from prior spec)
+                       ├── counter:    "Showing X of Y"  (aria-live)    (unchanged)
+                       ├── unknown-tags banner                          (unchanged)
+                       ├── empty state                                  (copy adapted)
+                       ├── post grid:  20 calls to partials/post-filter-page.hbs (page=1..20)
+                       │       │
+                       │       └── each renders {{#get "posts" limit=100 page=N filter=filter}}
+                       │           wrapping each post in <div class="filter-card-wrapper" x-show="isVisible($el)">
+                       │
+                       └── load-more button                             (unchanged)
+
+                                            ↓ x-data="postFilterList(...)"
+
+                       assets/js/post-filter-list.js
+                            ├── filter chip state, sort state, search state
+                            ├── reactivity, URL sync
+                            └── delegates network calls to:
+                                    assets/js/typesense-search.js
+                                          ├── fetch() against https://typesense.advisory.sg/...
+                                          ├── AbortController per query
+                                          └── returns Promise<Set<slug>>
+```
+
+## Files
+
+| Path                            | Action    | Purpose                                                                                                                                                                                                                                                        |
+| ------------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `partials/post-filter-list.hbs` | Modify    | Add toolbar (search + sort); replace single `{{#get limit="all"}}` with 20 calls to sub-partial; thread new params.                                                                                                                                            |
+| `partials/post-filter-page.hbs` | **New**   | Tiny partial: one `{{#get limit="100" page=page filter=filter}}` block. ~10 lines.                                                                                                                                                                             |
+| `partials/post-card.hbs`        | Modify    | Add `data-slug="{{slug}}"` to `<article>`. Add `data-title="{{title}}"` and `data-published-at="{{date published_at format='YYYY-MM-DDTHH:mm:ss'}}"` (explicit field arg) for client-side sort. (No `data-search-text` — search is server-side via Typesense.) |
+| `assets/js/post-filter-list.js` | Modify    | Add `searchQuery`, `sortMode`, `searchSlugs`, `searchError`, `isSearching` state. Add search/sort to filter pipeline. Extend URL r/w.                                                                                                                          |
+| `assets/js/typesense-search.js` | **New**   | ~50-line wrapper. Exports `searchSlugs(query, tagSlugs, abortSignal): Promise<Set<string> \| null>`. Constants for host, key, collection at top of file.                                                                                                       |
+| `assets/js/main.js`             | No change | Component already registered.                                                                                                                                                                                                                                  |
+| `events.hbs`                    | Modify    | Add `tagSlugs="hash-insights,hash-insights-2"` to the partial call. Existing `filter` param unchanged.                                                                                                                                                         |
+| `interviews.hbs`                | Modify    | Add `tagSlugs="hash-conversations,hash-conversations-2,hash-conversations-3,hash-reflections,hash-reflections-2"`.                                                                                                                                             |
+| `config/routes.yaml`            | No change | Tag lists stay where they are; templates duplicate them in `tagSlugs` form.                                                                                                                                                                                    |
+
+## Data flow
+
+State (all reactive):
+
+```
+selectedTags  : string[]            // chip selection
+searchQuery   : string              // raw input value
+searchSlugs   : Set<string> | null  // null = no search active or query < 2 chars
+                                    // Set = the slugs Typesense returned
+isSearching   : boolean             // request in-flight, drives spinner
+searchError   : boolean             // Typesense unreachable
+sortMode      : 'newest'|'oldest'|'az'|'za'
+visibleCount  : number              // load-more pagination
+```
+
+Pipeline (every render):
+
+```
+allCards
+   ↓ filter by selectedTags  (chip mode: OR default; AND switchable)
+tagFiltered
+   ↓ if (searchSlugs !== null): keep only cards where searchSlugs.has(card.slug)
+   ↓ else: passthrough
+searchAndTagFiltered
+   ↓ sort by sortMode
+sorted
+   ↓ slice(0, visibleCount)
+visible          ← what `x-show="isVisible($el)"` renders
+```
+
+Triggers:
+
+| Action                | What happens                                                                                                                                                                           |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Toggle chip           | `selectedTags` updates. `visibleCount` resets to PAGE_SIZE.                                                                                                                            |
+| Type in search input  | After 250ms debounce: if query.length < 2, set `searchSlugs = null`; else fire Typesense (abort prior in-flight). Set `isSearching = true`.                                            |
+| Typesense response    | `searchSlugs ← Set(response.hits.map(h => h.document.slug))`. `isSearching = false`. `visibleCount` resets.                                                                            |
+| Typesense error       | `searchError = true`. `searchSlugs = null` (so search doesn't filter anything). `isSearching = false`.                                                                                 |
+| Clear search input    | `searchSlugs = null`, `searchError = false`. No network call.                                                                                                                          |
+| Change sort           | `sortMode` updates. Cards re-ordered in DOM. `visibleCount` resets.                                                                                                                    |
+| Click "Load more"     | `visibleCount += PAGE_SIZE`. Focus moves to first newly-revealed card (existing behaviour).                                                                                            |
+| Click "Clear filters" | Clears `selectedTags`, `searchQuery`, **and** `searchSlugs`. Resets `sortMode` to `newest`. URL params drop to bare path. (Extends prior behaviour which only cleared `selectedTags`.) |
+
+## URL state
+
+| Param  | Format                               | Default (omitted from URL) |
+| ------ | ------------------------------------ | -------------------------- |
+| `tags` | `slug1,slug2,…`                      | empty array                |
+| `q`    | percent-encoded raw query string     | empty string               |
+| `sort` | `newest` \| `oldest` \| `az` \| `za` | `newest`                   |
+
+Writes use `history.replaceState` (do not flood Back button). All three params write together via the same handler — `init()` reads them once on load and seeds initial state.
+
+URL examples:
+
+-   `/events/` — no params, shows everything sorted newest first
+-   `/events/?tags=hash-insights` — chip preselected
+-   `/events/?q=stoic` — search preseeded; Typesense fired in `init()`
+-   `/events/?tags=hash-insights&q=banking&sort=oldest` — all three active
+
+## Network traffic
+
+**Per Typesense request:**
+
+-   **Out:** ~500 bytes (URL ~200 chars + headers + TLS/HTTP-2 overhead). One `X-TYPESENSE-API-KEY` header.
+-   **In:** With `include_fields=slug`, each hit ≈ 50 bytes. Typical query (5-20 hits) ≈ 1-2 KB. Pathological maximum (250 hits = `per_page` cap) ≈ 12 KB. Halve those for gzip.
+-   **Latency:** ~50-150 ms RTT for SG/SEA users; 200-400 ms overseas.
+
+**First request from a fresh page:**
+
+-   Browser issues a CORS preflight (`OPTIONS`) before the first `GET` — adds one extra round-trip of ~200 bytes. Cached for the page lifetime; subsequent searches don't preflight.
+
+**Per page load (no search yet):**
+
+-   **Zero** Typesense traffic. The component fires only when the user types into the search input (and only after the 250ms debounce, and only when query length ≥ 2).
+
+**Per search session** (one query typed, average 5 chars):
+
+-   Debounce coalesces fast typing to ~1 request per 250ms → 2-3 requests for a typical word.
+-   Total session: ~5-15 KB.
+
+**Daily heavy user** (5 search sessions): ~25-75 KB. Negligible.
+
+**Comparison to the in-DOM alternative considered and rejected:**
+
+|                      | In-DOM search (rejected)               | Typesense (chosen) |
+| -------------------- | -------------------------------------- | ------------------ |
+| Initial page weight  | +400 KB (plaintext attrs on each card) | 0                  |
+| Per search session   | 0                                      | ~5-15 KB           |
+| Per day (heavy user) | 0                                      | ~25-75 KB          |
+
+Typesense is overall lighter for typical browsing because the up-front payload cost dominates the per-query cost.
+
+## Typesense request shape
+
+```
+GET https://typesense.advisory.sg/collections/ghost/documents/search
+    ?q=<encoded query>
+    &query_by=title,excerpt,plaintext
+    &query_by_weights=4,2,1
+    &include_fields=slug
+    &per_page=250
+    &filter_by=tags.slug:[<page tag slugs joined by comma>]
+
+Headers:
+    X-TYPESENSE-API-KEY: LWQ1uyADTZBRVJa0XuFY5BcipgnhvQ8g
+```
+
+Response (relevant fields only):
+
+```
+{
+    "found": 7,
+    "hits": [
+        { "document": { "slug": "conversations-with-foo" } },
+        ...
+    ]
+}
+```
+
+`searchSlugs ← new Set(hits.map(h => h.document.slug))`.
+
+Schema verified live on 2026-05-06: collection `ghost`, 283 documents, indexed fields include `title`, `slug`, `excerpt`, `plaintext`, `tags.slug`, `tags.name`, `published_at`, `updated_at`, `authors`, `url`, `feature_image`, `html`.
+
+## Error handling and edge cases
+
+-   **Typesense unreachable / 5xx / non-JSON response:** Catch in `typesense-search.js`, propagate as a rejected promise. `post-filter-list.js` sets `searchError = true`, leaves `searchSlugs = null` (so search becomes a passthrough). Banner appears: _"Search temporarily unavailable. Filters and sorting still work."_ Banner clears when user clears the search input.
+-   **Aborted in-flight request** (user typed again before previous returned): `AbortController.abort()`. The rejected promise must be distinguishable from a real error — `if (err.name === 'AbortError') return;` so we don't set `searchError`.
+-   **Empty query / query < 2 chars:** `searchSlugs = null`. Pipeline skips the search filter entirely. No network call.
+-   **Typesense returns 0 hits:** `searchSlugs = new Set()`. Pipeline filters everything out → empty state. Empty-state copy adapts: _"No posts match your search."_ / _"…your search and filters."_ / _"…your selected tags."_ depending on which inputs are active.
+-   **`?q=…` in URL on initial load:** `init()` seeds `searchQuery`, fires Typesense after Alpine mount. While in-flight, grid renders unfiltered (since `searchSlugs` is still `null`). Acceptable brief flash; alternative (hide grid until first search resolves) penalises every user for a query that nearly always returns >0 results.
+-   **Search with regex/emoji/special characters:** Typesense handles these natively; we only `encodeURIComponent` the query for URL safety.
+-   **Unknown sort value in URL** (`?sort=garbage`): silently fall back to `newest`. No banner.
+-   **Unknown tag slugs in URL:** existing amber banner behaviour (kept from prior spec).
+-   **Sort during ongoing search:** Sort runs over whatever `searchSlugs` is _now_. When the search response arrives, the pipeline re-runs and re-sorts. No special handling needed.
+-   **CORS not configured on Typesense host:** First request fails preflight. `searchError = true`, banner shows. Operationally a one-time setup issue, not a runtime concern.
+-   **Hard page-load ceiling reached** (>2000 events or interviews): the 21st page never renders. Posts beyond rank 2000 are invisible to the chip filter and sort, AND any Typesense slug match for them produces a silent drop (slug not in any loaded card). At current growth rate this is years away. Documented for future re-evaluation when total approaches 1500.
+
+## Accessibility
+
+-   **Search input:** `<label for="post-search-{{collection}}" class="sr-only">Search posts</label>` paired with visible placeholder. `aria-controls` references the grid id. Pressing `Esc` clears the input and refocuses it.
+-   **Sort dropdown:** native `<select>` with visible `<label>` ("Sort:"). Best out-of-box screen reader and keyboard support; no ARIA required.
+-   **Searching indicator:** small `<span aria-live="polite">Searching…</span>` next to the input while `isSearching`. Disappears on response.
+-   **Live region** (existing): `role="status" aria-live="polite"` announces _"Showing X of Y"_ on every state change. Debounced naturally by Alpine reactivity timing — no per-keystroke spam because the search itself is debounced.
+-   **Error banner:** `role="alert"` for the Typesense-unavailable case so it's announced when it appears.
+-   **Empty-state copy** is announced via the live region (counter shows "0 of N").
+-   **Keyboard tab order:** search input → sort dropdown → chips → first card → load-more.
+-   **No focus trap, no modal patterns.**
+
+## Testing and verification
+
+No automated tests (theme has no test framework). Manual verification matrix to be exercised in the implementation phase:
+
+1. Page loads `/events/` — toolbar visible, chips visible, all 287-or-so posts present in DOM.
+2. Type "stoic" → results narrow live, count updates, URL gets `?q=stoic`.
+3. Click an interviews-related chip → chip toggles state. Combined with search, AND-narrows.
+4. Change sort to "Title A→Z" → cards visually reorder. Sort persists in URL.
+5. Refresh `/events/?q=banking&tags=hash-insights&sort=oldest` → all three pre-applied correctly.
+6. Disconnect from Typesense (block `typesense.advisory.sg` in DevTools) → banner appears on next search; chips and sort still work.
+7. Type "x" (one char) → no Typesense request fires. Type "xy" → request fires.
+8. Type fast: open Network panel and confirm in-flight requests get cancelled (`status: cancelled`).
+9. Disable JavaScript → all 287 posts visible in static grid; no toolbar; no chip UI. Acceptable degradation.
+10. Mobile viewport (375px) → toolbar wraps to two rows (search above, sort below).
+11. Tab through controls with keyboard, screen reader on (NVDA / VoiceOver). Searching state, count, error banner all announce.
+12. Same matrix on `/interviews/`.
+13. Verify `/posts/` (uses `index.hbs`) is **not** affected — no toolbar, no chips, plain grid.
+
+## Future migration paths
+
+Documented to avoid surprise later, **not** committed to in this spec:
+
+-   **Approach C migration (full corpus past 2000 posts):** when post count approaches 1500, re-evaluate. Replace the 20 SSR blocks with first-100 SSR + JS Content API fetch loop for pages 2..N. Card identity (`data-slug`) stays the same. Search and sort code unchanged.
+-   **Per-environment Typesense host/key:** swap the constants in `typesense-search.js` for build-time `process.env.*` injection via webpack `DefinePlugin`. The component boundary doesn't change.
+-   **Replace native sort with a styled menu:** drop-in if design ever wants it. Adapter point is the `<select>` element.
+-   **Add relevance-ranked sort:** would need to surface Typesense's hit order; currently we discard it. Add an `'relevance'` sortMode that bypasses client-side sort and uses the slug arrival order from Typesense.
+
+## Out of scope (re-emphasised)
+
+-   Typesense indexing / sync mechanism — handled separately.
+-   Replacing the existing chip filter with Typesense `filter_by` — chips stay client-side because they're already implemented and fast.
+-   Post-card visual changes beyond adding three data attributes.
+-   Touching `/posts/`, tag pages, or any non-events/interviews listing.
+-   Any change to `routes.yaml` content (tag slug lists are duplicated into the templates as a `tagSlugs` parameter; routes.yaml stays the source of truth).
+-   Search analytics, search history, suggestions, autocomplete, highlighting.

--- a/docs/superpowers/specs/2026-05-06-sort-filter-design.md
+++ b/docs/superpowers/specs/2026-05-06-sort-filter-design.md
@@ -1,0 +1,293 @@
+# Sort & Filter on Interviews and Events — Design
+
+**Date:** 2026-05-06
+**Status:** Approved, ready for implementation planning
+**Related:** `2026-05-06-features-overview.md`
+
+## Goal
+
+Let readers filter the post listings on `/events/` and `/interviews/` by tag,
+in place, without leaving the page. URL reflects the active filter so it can
+be bookmarked and shared.
+
+Sort is fixed at newest-first (no sort UI in v1).
+
+## Non-goals
+
+-   Sort controls (date is fixed newest-first)
+-   Filter by author, year, or full-text search
+-   Filter on `/posts/`, tag pages, or any other listing
+-   Server-side filter routing (Ghost `routes.yaml` collection variants)
+-   Analytics events on filter changes
+-   Suggested-articles improvements (Feature 2 — separate spec)
+
+## Decisions and rationale
+
+| Decision                     | Choice                                              | Rationale                                                                                              |
+| ---------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Architecture                 | Client-side filter over server-rendered post list   | Few hundred posts is small enough to fit in DOM. Avoids Content API auth and fetch latency.            |
+| Filter dimensions            | Tag only, multi-select                              | User-requested. Author/year deferred to YAGNI.                                                         |
+| Combine mode                 | OR by default, AND switchable via partial parameter | Default chosen for broader results / less empty-state surprise. AND code path required for future use. |
+| Sort                         | Fixed `published_at desc`                           | User chose only this option. No UI needed.                                                             |
+| Pagination                   | "Load more" button, batch 12                        | Matches existing `posts_per_page`, simpler than numbered pages, no `page` URL param.                   |
+| URL state                    | `?tags=<slug>,<slug>` only                          | Filter state is shareable and survives refresh; load-more state is ephemeral.                          |
+| History API                  | `replaceState` (not `pushState`)                    | Chip toggles should not flood browser history. Back button still navigates pages.                      |
+| Unknown tag slugs in URL     | Kept in `selectedTags`, surfaced in amber banner    | User-requested over silent drop, makes stale links visible.                                            |
+| Generic `/posts/` collection | No filter UI                                        | `index.hbs` is shared; we create a dedicated `interviews.hbs` rather than conditionally render.        |
+
+## Architecture
+
+```
+events.hbs ─────┐
+                ├──> partials/post-filter-list.hbs
+interviews.hbs ─┘         │
+                          ├── filter chips (Alpine x-data)
+                          ├── server-rendered list of all matching posts
+                          ├── "X of Y" counter (aria-live)
+                          ├── unknown-tags banner (conditional)
+                          ├── empty state (conditional)
+                          └── "Load more" button (conditional)
+
+assets/js/post-filter-list.js  ──> Alpine.data('postFilterList', ...)
+assets/js/main.js              ──> imports + registers component
+```
+
+## Files
+
+### New files
+
+-   `interviews.hbs` — mirrors current `index.hbs`, renders
+    `{{> post-filter-list collection="interviews"}}`.
+-   `partials/post-filter-list.hbs` — filter UI + post grid + load-more.
+    Accepts `collection` (string) and `mode` (`"or"` default, `"and"`).
+-   `assets/js/post-filter-list.js` — Alpine component definition. Default
+    export is the registration function so `main.js` can call
+    `Alpine.data('postFilterList', register())`.
+
+### Modified files
+
+-   `events.hbs` — replace tags-listing + foreach + pagination block with
+    `{{> post-filter-list collection="events"}}`.
+-   `partials/post-card.hbs` — add `data-tags="<comma-separated slugs>"` to
+    the root `<article>` element. Built from
+    `{{#foreach tags visibility="public"}}{{slug}}{{#unless @last}},{{/unless}}{{/foreach}}`.
+    Internal tags (hash-prefixed routing tags such as `#insights`,
+    `#conversations`) are excluded so they don't surface as filter chips.
+-   `assets/js/main.js` — import `post-filter-list.js`, register the
+    Alpine component before `Alpine.start()`.
+-   `config/routes.yaml` — change `/interviews/` template from `index` to
+    `interviews`.
+
+### Untouched files
+
+-   `partials/tags-listing.hbs` — left as-is (no longer rendered by
+    events/interviews, but harmless).
+-   `index.hbs` — still serves `/posts/` without filter UI.
+-   `tag.hbs` — still serves `/tag/<slug>/` without filter UI.
+
+## Component interface
+
+### Partial
+
+```handlebars
+{{> post-filter-list
+    collection="events"
+    filter="tag:hash-insights"
+    mode="or"}}
+```
+
+-   `collection` — string label, used for the wrapper DOM id and as a
+    namespace prefix if both filters ever appear on the same page.
+-   `filter` — Ghost filter string passed straight to `{{#get "posts"}}`.
+    Mirrors the collection filter from `routes.yaml`
+    (`tag:hash-insights` for events,
+    `tag:[hash-conversations,hash-reflections]` for interviews) so the
+    partial fetches the same set the page would have rendered.
+-   `mode` — `"or"` (default) or `"and"`. Selects matching function.
+
+### Alpine component
+
+```javascript
+Alpine.data("postFilterList", ({ collection, mode }) => ({
+    selectedTags: [], // tag slugs currently active
+    visibleCount: 12, // load-more counter
+    allCards: [], // [{ el: HTMLElement, tagSlugs: Set<string> }]
+    availableTags: [], // [{ slug, name }] — tags present on this page
+
+    init() {
+        this.allCards = this._readCardsFromDom();
+        this.availableTags = this._buildAvailableTags();
+        this.selectedTags = this._readTagsFromUrl();
+        this.$watch("selectedTags", () => {
+            this.visibleCount = 12;
+            this._writeTagsToUrl();
+        });
+    },
+
+    matches(card) {
+        if (this.selectedTags.length === 0) return true;
+        if (mode === "and") {
+            return this.selectedTags.every((t) => card.tagSlugs.has(t));
+        }
+        return this.selectedTags.some((t) => card.tagSlugs.has(t));
+    },
+
+    filtered() {
+        return this.allCards.filter((c) => this.matches(c));
+    },
+    visible() {
+        return this.filtered().slice(0, this.visibleCount);
+    },
+
+    unknownTags() {
+        const known = new Set(this.availableTags.map((t) => t.slug));
+        return this.selectedTags.filter((s) => !known.has(s));
+    },
+
+    toggleTag(slug) {
+        /* add or remove */
+    },
+    loadMore() {
+        this.visibleCount += 12;
+    },
+    clearFilters() {
+        this.selectedTags = [];
+    },
+}));
+```
+
+Display is driven by `x-show` on each card (rather than rerendering the
+list) — Alpine's reactivity hides cards that don't match or fall outside
+`visibleCount`.
+
+## Data flow
+
+### Page load
+
+1. Ghost resolves `/events/` → `events.hbs` → renders
+   `{{> post-filter-list collection="events"}}`.
+2. Partial calls
+   `{{#get "posts" limit="1000" filter=filter include="tags" order="published_at desc"}}`
+   (where `filter` is the partial parameter — `tag:hash-insights` for
+   events, `tag:[hash-conversations,hash-reflections]` for interviews)
+   to fetch every matching post in one query.
+3. Each post renders as a `post-card` with
+   `data-tags="<slug-1>,<slug-2>"` on the root `<article>`.
+4. Alpine `init()` runs:
+    - Reads `?tags=` from URL into `selectedTags`.
+    - Walks the DOM, builds `allCards` and `availableTags`.
+5. Reactive bindings show/hide cards according to `matches()` and
+   `visibleCount`. Counter and load-more state render accordingly.
+
+### Toggle a chip
+
+1. `toggleTag(slug)` updates `selectedTags`.
+2. `$watch('selectedTags')` resets `visibleCount` to 12 and rewrites the URL.
+3. Cards re-evaluate `x-show`.
+4. Empty state, unknown-tags banner, and load-more visibility update reactively.
+
+### Load more
+
+1. `visibleCount += 12`. Cards in the new range become visible.
+2. URL is **not** updated.
+3. Focus moves to the first newly-revealed card for keyboard users.
+
+### URL handling
+
+-   Read on init:
+    ```js
+    const params = new URLSearchParams(location.search);
+    const raw = params.get("tags") || "";
+    return raw.split(",").filter(Boolean);
+    ```
+-   Write on change (via `$watch`):
+    ```js
+    const params = new URLSearchParams(location.search);
+    if (this.selectedTags.length) {
+        params.set("tags", this.selectedTags.join(","));
+    } else {
+        params.delete("tags");
+    }
+    const qs = params.toString();
+    history.replaceState(
+        null,
+        "",
+        qs ? `${location.pathname}?${qs}` : location.pathname,
+    );
+    ```
+
+### Matching
+
+```
+match(card):
+  if selectedTags.length === 0 → true
+  if mode === "or"  → selectedTags.some(t => card.tagSlugs.has(t))
+  if mode === "and" → selectedTags.every(t => card.tagSlugs.has(t))
+```
+
+## Edge cases
+
+| Case                                                  | Behavior                                                                                                                             |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| No selected tags                                      | All posts show.                                                                                                                      |
+| Selected tag exists on this page                      | Filter applies normally.                                                                                                             |
+| Selected tag does not exist on this page (any reason) | Card filter naturally returns 0; amber banner lists the unknown slugs.                                                               |
+| URL has empty/malformed `?tags=`                      | `.filter(Boolean)` strips empties; nothing breaks.                                                                                   |
+| Filter applied → load more clicked → filter changed   | `visibleCount` resets to 12.                                                                                                         |
+| Zero matches, no unknown tags                         | Empty-state message + `[Clear filters]` button.                                                                                      |
+| Zero matches, with unknown tags                       | Amber banner + empty-state message + `[Clear filters]`.                                                                              |
+| JS disabled or fails to load                          | Server-rendered list of all matching posts is fully visible and readable. Filter UI is non-interactive but page degrades gracefully. |
+| Collection has more than 1000 posts                   | Graceful failure: only first 1000 render. We revisit and switch to Content API if/when it happens.                                   |
+
+## SEO
+
+-   Add `<link rel="canonical" href="{{@site.url}}{{path}}">` to the new
+    `interviews.hbs` and to `events.hbs` if `{{ghost_head}}` does not already
+    emit one. Filtered URLs (`?tags=...`) canonicalize to the unfiltered page.
+-   No `noindex` on filtered URLs — they're useful for direct visits.
+
+## Accessibility
+
+-   Chips are `<button type="button" role="checkbox" :aria-checked="selected">`.
+-   Selection communicated by both color and a checkmark icon (not color
+    alone).
+-   Counter wrapped in `<div role="status" aria-live="polite">`.
+-   Empty-state message and unknown-tags banner are real text, focusable
+    buttons.
+-   "Load more" is a `<button>`. After click, focus moves to the first
+    newly-revealed card.
+
+## Testing
+
+No test framework added. Validation comes from:
+
+1. **`npm run test`** (gscan) — must pass with no errors.
+2. **`npm run dev`** (gulp + webpack + tailwind) — must complete clean.
+3. **Manual scenarios** against `localhost:2368`:
+    - Filter on/off, single tag, multiple tags (OR)
+    - Clear filters
+    - Load more, then filter change resets count
+    - URL preload: valid tags, unknown tags, mixed, malformed, empty
+    - Repeat on `/interviews/` with interview tag set
+    - `/posts/` and `/tag/<slug>/` show no filter UI
+    - JS disabled → page still readable
+    - Keyboard tab + space toggles chips, `aria-live` announces counts
+    - Mobile viewport: chips wrap, layout doesn't break
+    - Switch `mode="and"` in `events.hbs`, rebuild, verify two chips → both-required behavior, then revert
+
+## Open questions for implementation
+
+-   Does `{{ghost_head}}` already emit a canonical URL? Check during
+    implementation; only add manual `<link rel="canonical">` if missing.
+-   Is there an existing Tailwind component pattern for buttons / pills in
+    this theme? Check `assets/css` and reuse if so.
+
+## Out of scope (deferred)
+
+-   Sort controls
+-   Author / year filters
+-   Analytics events on filter changes
+-   Filter on generic `/posts/`, tag, or author pages
+-   Filter persistence beyond URL (no localStorage)
+-   Server-side filtering or Content API fallback (only if collections grow
+    past ~1000 posts)

--- a/events.hbs
+++ b/events.hbs
@@ -7,7 +7,9 @@
         <header class="single-header kg-canvas">
             <h1 class="single-title">Events</h1>
         </header>
-        {{!-- filter must match config/routes.yaml /events/ filter exactly --}}
+        {{!-- filter and tagSlugs must mirror config/routes.yaml /events/ filter
+              exactly. tagSlugs is the same slug list as filter=tag:[...], in
+              the format Typesense's filter_by accepts (plain comma-separated). --}}
         {{> post-filter-list collection="events" filter="tag:[hash-insights,hash-insights-2]" tagSlugs="hash-insights,hash-insights-2" mode="or"}}
     </main>
 </div>

--- a/events.hbs
+++ b/events.hbs
@@ -7,6 +7,7 @@
         <header class="single-header kg-canvas">
             <h1 class="single-title">Events</h1>
         </header>
+        {{!-- filter must match config/routes.yaml /events/ filter exactly --}}
         {{> post-filter-list collection="events" filter="tag:[hash-insights,hash-insights-2]" mode="or"}}
     </main>
 </div>

--- a/events.hbs
+++ b/events.hbs
@@ -7,12 +7,6 @@
         <header class="single-header kg-canvas">
             <h1 class="single-title">Events</h1>
         </header>
-        {{> tags-listing context="events"}}
-        <div class="post-feed container grid grid-cols-1 lg:grid-cols-3 gap-x-20 gap-y-10 m-auto">
-            {{#foreach posts}}
-                {{> "post-card"}}
-            {{/foreach}}
-        </div>
-        {{pagination}}
+        {{> post-filter-list collection="events" filter="tag:hash-insights" mode="or"}}
     </main>
 </div>

--- a/events.hbs
+++ b/events.hbs
@@ -7,6 +7,6 @@
         <header class="single-header kg-canvas">
             <h1 class="single-title">Events</h1>
         </header>
-        {{> post-filter-list collection="events" filter="tag:hash-insights" mode="or"}}
+        {{> post-filter-list collection="events" filter="tag:[hash-insights,hash-insights-2]" mode="or"}}
     </main>
 </div>

--- a/events.hbs
+++ b/events.hbs
@@ -8,6 +8,6 @@
             <h1 class="single-title">Events</h1>
         </header>
         {{!-- filter must match config/routes.yaml /events/ filter exactly --}}
-        {{> post-filter-list collection="events" filter="tag:[hash-insights,hash-insights-2]" mode="or"}}
+        {{> post-filter-list collection="events" filter="tag:[hash-insights,hash-insights-2]" tagSlugs="hash-insights,hash-insights-2" mode="or"}}
     </main>
 </div>

--- a/index.hbs
+++ b/index.hbs
@@ -1,13 +1,12 @@
 {{!< default}}
 
-{{#contentFor "title"}}Interviews{{/contentFor}}
+{{#contentFor "title"}}Posts{{/contentFor}}
 
 <div class="content-area">
     <main class="site-main">
         <header class="single-header kg-canvas">
-            <h1 class="single-title">Interviews</h1>
+            <h1 class="single-title">Posts</h1>
         </header>
-        {{> tags-listing context="interviews"}}
         <div class="post-feed container grid grid-cols-1 lg:grid-cols-3 gap-x-20 gap-y-10 m-auto">
             {{#foreach posts}}
                 {{> "post-card"}}

--- a/interviews.hbs
+++ b/interviews.hbs
@@ -8,9 +8,6 @@
             <h1 class="single-title">Interviews</h1>
         </header>
         {{!-- filter must match config/routes.yaml /interviews/ filter exactly --}}
-        {{> post-filter-list
-            collection="interviews"
-            filter="tag:[hash-conversations,hash-conversations-2,hash-conversations-3,hash-reflections,hash-reflections-2]"
-            mode="or"}}
+        {{> post-filter-list collection="interviews" filter="tag:[hash-conversations,hash-conversations-2,hash-conversations-3,hash-reflections,hash-reflections-2]" tagSlugs="hash-conversations,hash-conversations-2,hash-conversations-3,hash-reflections,hash-reflections-2" mode="or"}}
     </main>
 </div>

--- a/interviews.hbs
+++ b/interviews.hbs
@@ -9,7 +9,7 @@
         </header>
         {{> post-filter-list
             collection="interviews"
-            filter="tag:[hash-conversations,hash-reflections]"
+            filter="tag:[hash-conversations,hash-conversations-2,hash-conversations-3,hash-reflections,hash-reflections-2]"
             mode="or"}}
     </main>
 </div>

--- a/interviews.hbs
+++ b/interviews.hbs
@@ -7,7 +7,9 @@
         <header class="single-header kg-canvas">
             <h1 class="single-title">Interviews</h1>
         </header>
-        {{!-- filter must match config/routes.yaml /interviews/ filter exactly --}}
+        {{!-- filter and tagSlugs must mirror config/routes.yaml /interviews/
+              filter exactly. tagSlugs is the same slug list as filter=tag:[...],
+              in the format Typesense's filter_by accepts (plain comma-separated). --}}
         {{> post-filter-list collection="interviews" filter="tag:[hash-conversations,hash-conversations-2,hash-conversations-3,hash-reflections,hash-reflections-2]" tagSlugs="hash-conversations,hash-conversations-2,hash-conversations-3,hash-reflections,hash-reflections-2" mode="or"}}
     </main>
 </div>

--- a/interviews.hbs
+++ b/interviews.hbs
@@ -7,6 +7,7 @@
         <header class="single-header kg-canvas">
             <h1 class="single-title">Interviews</h1>
         </header>
+        {{!-- filter must match config/routes.yaml /interviews/ filter exactly --}}
         {{> post-filter-list
             collection="interviews"
             filter="tag:[hash-conversations,hash-conversations-2,hash-conversations-3,hash-reflections,hash-reflections-2]"

--- a/interviews.hbs
+++ b/interviews.hbs
@@ -1,0 +1,15 @@
+{{!< default}}
+
+{{#contentFor "title"}}Interviews{{/contentFor}}
+
+<div class="content-area">
+    <main class="site-main">
+        <header class="single-header kg-canvas">
+            <h1 class="single-title">Interviews</h1>
+        </header>
+        {{> post-filter-list
+            collection="interviews"
+            filter="tag:[hash-conversations,hash-reflections]"
+            mode="or"}}
+    </main>
+</div>

--- a/package.json
+++ b/package.json
@@ -90,6 +90,18 @@
                 "type": "boolean",
                 "default": true,
                 "group": "post"
+            },
+            "typesense_host": {
+                "type": "text",
+                "default": "https://typesense.advisory.sg"
+            },
+            "typesense_api_key": {
+                "type": "text",
+                "default": "LWQ1uyADTZBRVJa0XuFY5BcipgnhvQ8g"
+            },
+            "typesense_collection": {
+                "type": "text",
+                "default": "ghost"
             }
         }
     },

--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -1,8 +1,7 @@
 <article
     class="feed-card {{post_class}} rounded-lg shadow-2xl m-auto w-full max-w-2xl md:max-w-full lg:h-full hover:shadow-md hover:border-opacity-0 transform hover:-translate-y-1 transition-all duration-200"
     data-tags="{{#foreach tags visibility='public'}}{{slug}}{{#unless @last}},{{/unless}}{{/foreach}}"
-    data-tag-names="{{#foreach tags visibility='public'}}{{name}}{{#unless @last}}|{{/unless}}{{/foreach}}"
-    tabindex="-1">
+    data-tag-names="{{#foreach tags visibility='public'}}{{name}}{{#unless @last}}|{{/unless}}{{/foreach}}">
     <div onclick="location.href='{{url}}'" class="flex flex-col cursor-pointer h-full rounded-xl overflow-hidden md:flex-row md:h-80 lg:flex-col lg:h-full">
         {{#if feature_image}}
         <img class="object-cover m-0 h-full md:aspect-[9/5] lg:h-auto lg:aspect-[15/8]" src="{{img_url feature_image}}" alt="{{title}}" />

--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -1,7 +1,7 @@
 <article
     class="feed-card {{post_class}} rounded-lg shadow-2xl m-auto w-full max-w-2xl md:max-w-full lg:h-full hover:shadow-md hover:border-opacity-0 transform hover:-translate-y-1 transition-all duration-200"
-    data-tags="{{#foreach tags visibility="public"}}{{slug}}{{#unless @last}},{{/unless}}{{/foreach}}"
-    data-tag-names="{{#foreach tags visibility="public"}}{{name}}{{#unless @last}},{{/unless}}{{/foreach}}">
+    data-tags="{{#foreach tags visibility='public'}}{{slug}}{{#unless @last}},{{/unless}}{{/foreach}}"
+    data-tag-names="{{#foreach tags visibility='public'}}{{name}}{{#unless @last}}|{{/unless}}{{/foreach}}">
     <div onclick="location.href='{{url}}'" class="flex flex-col cursor-pointer h-full rounded-xl overflow-hidden md:flex-row md:h-80 lg:flex-col lg:h-full">
         {{#if feature_image}}
         <img class="object-cover m-0 h-full md:aspect-[9/5] lg:h-auto lg:aspect-[15/8]" src="{{img_url feature_image}}" alt="{{title}}" />

--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -1,7 +1,8 @@
 <article
     class="feed-card {{post_class}} rounded-lg shadow-2xl m-auto w-full max-w-2xl md:max-w-full lg:h-full hover:shadow-md hover:border-opacity-0 transform hover:-translate-y-1 transition-all duration-200"
     data-tags="{{#foreach tags visibility='public'}}{{slug}}{{#unless @last}},{{/unless}}{{/foreach}}"
-    data-tag-names="{{#foreach tags visibility='public'}}{{name}}{{#unless @last}}|{{/unless}}{{/foreach}}">
+    data-tag-names="{{#foreach tags visibility='public'}}{{name}}{{#unless @last}}|{{/unless}}{{/foreach}}"
+    tabindex="-1">
     <div onclick="location.href='{{url}}'" class="flex flex-col cursor-pointer h-full rounded-xl overflow-hidden md:flex-row md:h-80 lg:flex-col lg:h-full">
         {{#if feature_image}}
         <img class="object-cover m-0 h-full md:aspect-[9/5] lg:h-auto lg:aspect-[15/8]" src="{{img_url feature_image}}" alt="{{title}}" />

--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -1,4 +1,7 @@
-<article class="feed-card {{post_class}} rounded-lg shadow-2xl m-auto w-full max-w-2xl md:max-w-full lg:h-full hover:shadow-md hover:border-opacity-0 transform hover:-translate-y-1 transition-all duration-200">
+<article
+    class="feed-card {{post_class}} rounded-lg shadow-2xl m-auto w-full max-w-2xl md:max-w-full lg:h-full hover:shadow-md hover:border-opacity-0 transform hover:-translate-y-1 transition-all duration-200"
+    data-tags="{{#foreach tags visibility="public"}}{{slug}}{{#unless @last}},{{/unless}}{{/foreach}}"
+    data-tag-names="{{#foreach tags visibility="public"}}{{name}}{{#unless @last}},{{/unless}}{{/foreach}}">
     <div onclick="location.href='{{url}}'" class="flex flex-col cursor-pointer h-full rounded-xl overflow-hidden md:flex-row md:h-80 lg:flex-col lg:h-full">
         {{#if feature_image}}
         <img class="object-cover m-0 h-full md:aspect-[9/5] lg:h-auto lg:aspect-[15/8]" src="{{img_url feature_image}}" alt="{{title}}" />

--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -1,7 +1,10 @@
 <article
     class="feed-card {{post_class}} rounded-lg shadow-2xl m-auto w-full max-w-2xl md:max-w-full lg:h-full hover:shadow-md hover:border-opacity-0 transform hover:-translate-y-1 transition-all duration-200"
     data-tags="{{#foreach tags visibility='public'}}{{slug}}{{#unless @last}},{{/unless}}{{/foreach}}"
-    data-tag-names="{{#foreach tags visibility='public'}}{{name}}{{#unless @last}}|{{/unless}}{{/foreach}}">
+    data-tag-names="{{#foreach tags visibility='public'}}{{name}}{{#unless @last}}|{{/unless}}{{/foreach}}"
+    data-slug="{{slug}}"
+    data-title="{{title}}"
+    data-published-at="{{date published_at format='YYYY-MM-DD HH:mm:ss'}}">
     <div onclick="location.href='{{url}}'" class="flex flex-col cursor-pointer h-full rounded-xl overflow-hidden md:flex-row md:h-80 lg:flex-col lg:h-full">
         {{#if feature_image}}
         <img class="object-cover m-0 h-full md:aspect-[9/5] lg:h-auto lg:aspect-[15/8]" src="{{img_url feature_image}}" alt="{{title}}" />

--- a/partials/post-filter-list.hbs
+++ b/partials/post-filter-list.hbs
@@ -12,15 +12,17 @@
     <div
         x-cloak
         class="post-filter-toolbar container m-auto px-4 mb-6 flex flex-wrap gap-3 items-center">
-        <div class="flex-1 min-w-[200px] flex items-center gap-2">
+        {{!-- min-width inline because Tailwind 3.0 JIT in this project
+              doesn't reliably emit arbitrary values like min-w-[200px]. --}}
+        <div class="flex-1 flex items-center gap-2" style="min-width: 200px;">
             <label for="post-search-{{collection}}" class="sr-only">Search posts</label>
             <input
                 id="post-search-{{collection}}"
                 type="search"
-                placeholder="Search posts..."
+                placeholder="Search posts…"
                 :value="searchQuery"
                 @input="setSearchQuery($event.target.value)"
-                @keydown.escape="setSearchQuery(''); $event.target.focus()"
+                @keydown.escape="setSearchQuery('')"
                 aria-controls="post-grid-{{collection}}"
                 class="flex-1 px-3 py-2 rounded border border-gray-300 text-base">
             <span

--- a/partials/post-filter-list.hbs
+++ b/partials/post-filter-list.hbs
@@ -24,6 +24,7 @@
                 @input="setSearchQuery($event.target.value)"
                 @keydown.escape="setSearchQuery('')"
                 aria-controls="post-grid-{{collection}}"
+                style="height: 42px;"
                 class="flex-1 px-3 py-2 rounded border border-gray-300 text-base">
             <span
                 x-show="isSearching"
@@ -33,23 +34,12 @@
             </span>
         </div>
         <div class="flex flex-wrap items-center gap-2">
-            <div class="flex items-center gap-2">
-                <label for="post-sort-{{collection}}" class="text-base text-gray-700">Sort:</label>
-                <select
-                    id="post-sort-{{collection}}"
-                    x-model="sortMode"
-                    class="px-3 py-2 rounded border border-gray-300 text-base bg-white">
-                    <option value="newest">Newest first</option>
-                    <option value="oldest">Oldest first</option>
-                    <option value="az">Title A → Z</option>
-                    <option value="za">Title Z → A</option>
-                </select>
-            </div>
             <div
-                class="relative"
+                class="relative flex items-center gap-2"
                 x-show="availableTags.length > 0"
                 @click.outside="closeTagDropdown()"
                 @keydown.escape.window="closeTagDropdown()">
+                <label for="post-tags-{{collection}}" class="text-base text-gray-700">Tag:</label>
                 <button
                     type="button"
                     id="post-tags-{{collection}}"
@@ -57,6 +47,7 @@
                     :aria-expanded="tagDropdownOpen.toString()"
                     aria-haspopup="listbox"
                     aria-controls="post-tags-menu-{{collection}}"
+                    style="height: 42px;"
                     class="px-3 py-2 rounded border border-gray-300 text-base bg-white inline-flex items-center gap-2">
                     <span x-text="selectedTagLabel()"></span>
                     <span aria-hidden="true">▾</span>
@@ -85,6 +76,19 @@
                         Clear tags
                     </button>
                 </div>
+            </div>
+            <div class="flex items-center gap-2">
+                <label for="post-sort-{{collection}}" class="text-base text-gray-700">Sort:</label>
+                <select
+                    id="post-sort-{{collection}}"
+                    x-model="sortMode"
+                    style="height: 42px;"
+                    class="px-3 py-2 rounded border border-gray-300 text-base bg-white">
+                    <option value="newest">Newest first</option>
+                    <option value="oldest">Oldest first</option>
+                    <option value="az">Title A → Z</option>
+                    <option value="za">Title Z → A</option>
+                </select>
             </div>
             <button
                 type="button"

--- a/partials/post-filter-list.hbs
+++ b/partials/post-filter-list.hbs
@@ -8,7 +8,7 @@
     id="post-filter-{{collection}}"
     x-data="postFilterList({ collection: '{{collection}}', mode: '{{mode}}', tagSlugs: '{{tagSlugs}}' })"
     class="post-filter-list">
-    {{!-- Toolbar: search input (left, flex-1) + sort dropdown (right). --}}
+    {{!-- Toolbar: search input (left, flex-1) + sort/tags controls (right). --}}
     <div
         x-cloak
         class="post-filter-toolbar container m-auto px-4 mb-6 flex flex-wrap gap-3 items-center">
@@ -32,17 +32,67 @@
                 Searching…
             </span>
         </div>
-        <div class="flex items-center gap-2">
-            <label for="post-sort-{{collection}}" class="text-base text-gray-700">Sort:</label>
-            <select
-                id="post-sort-{{collection}}"
-                x-model="sortMode"
-                class="px-3 py-2 rounded border border-gray-300 text-base">
-                <option value="newest">Newest first</option>
-                <option value="oldest">Oldest first</option>
-                <option value="az">Title A → Z</option>
-                <option value="za">Title Z → A</option>
-            </select>
+        <div class="flex flex-wrap items-center gap-2">
+            <div class="flex items-center gap-2">
+                <label for="post-sort-{{collection}}" class="text-base text-gray-700">Sort:</label>
+                <select
+                    id="post-sort-{{collection}}"
+                    x-model="sortMode"
+                    class="px-3 py-2 rounded border border-gray-300 text-base bg-white">
+                    <option value="newest">Newest first</option>
+                    <option value="oldest">Oldest first</option>
+                    <option value="az">Title A → Z</option>
+                    <option value="za">Title Z → A</option>
+                </select>
+            </div>
+            <div
+                class="relative"
+                x-show="availableTags.length > 0"
+                @click.outside="closeTagDropdown()"
+                @keydown.escape.window="closeTagDropdown()">
+                <button
+                    type="button"
+                    id="post-tags-{{collection}}"
+                    @click="toggleTagDropdown()"
+                    :aria-expanded="tagDropdownOpen.toString()"
+                    aria-haspopup="listbox"
+                    aria-controls="post-tags-menu-{{collection}}"
+                    class="px-3 py-2 rounded border border-gray-300 text-base bg-white inline-flex items-center gap-2">
+                    <span x-text="selectedTagLabel()"></span>
+                    <span aria-hidden="true">▾</span>
+                </button>
+                <div
+                    id="post-tags-menu-{{collection}}"
+                    x-show="tagDropdownOpen"
+                    x-cloak
+                    class="absolute right-0 z-20 mt-2 w-64 max-h-80 overflow-y-auto rounded border border-gray-300 bg-white shadow">
+                    <template x-for="tag in availableTags" :key="tag.slug">
+                        <button
+                            type="button"
+                            role="checkbox"
+                            :aria-checked="isSelected(tag.slug)"
+                            @click="toggleTag(tag.slug)"
+                            class="w-full px-3 py-2 text-left text-base flex items-center gap-2 hover:bg-gray-50">
+                            <span aria-hidden="true" x-text="isSelected(tag.slug) ? '✓' : ''" class="w-4"></span>
+                            <span x-text="tag.name"></span>
+                        </button>
+                    </template>
+                    <button
+                        type="button"
+                        x-show="selectedTags.length > 0"
+                        @click="clearTags()"
+                        class="w-full px-3 py-2 text-left text-base text-gray-700 underline hover:text-gray-900">
+                        Clear tags
+                    </button>
+                </div>
+            </div>
+            <button
+                type="button"
+                @click="clearFilters()"
+                x-show="hasActiveFilters()"
+                class="px-3 py-2 text-base text-gray-700 underline hover:text-gray-900">
+                Clear filters
+            </button>
         </div>
     </div>
 
@@ -53,34 +103,6 @@
         role="alert"
         class="container m-auto px-4 mb-4 p-3 rounded border bg-red-50 border-red-200 text-red-900 text-base">
         Search temporarily unavailable. Filters and sorting still work.
-    </div>
-
-    {{!-- Filter chips: hidden until Alpine init via x-cloak --}}
-    <div
-        x-cloak
-        class="filter-chips container m-auto flex flex-wrap gap-2 mb-6 px-4"
-        x-show="availableTags.length > 0">
-        <template x-for="tag in availableTags" :key="tag.slug">
-            <button
-                type="button"
-                role="checkbox"
-                :aria-checked="isSelected(tag.slug)"
-                @click="toggleTag(tag.slug)"
-                :class="isSelected(tag.slug)
-                    ? 'bg-brand-light text-gray-900 border-gray-900'
-                    : 'bg-white text-gray-700 border-gray-300'"
-                class="px-4 py-2 rounded-full border text-base hover:border-gray-900 transition-colors inline-flex items-center gap-1">
-                <span x-show="isSelected(tag.slug)" aria-hidden="true">✓</span>
-                <span x-text="tag.name"></span>
-            </button>
-        </template>
-        <button
-            type="button"
-            @click="clearFilters()"
-            x-show="hasActiveFilters()"
-            class="px-4 py-2 rounded-full text-base text-gray-700 underline hover:text-gray-900">
-            Clear filters
-        </button>
     </div>
 
     {{!-- Live result count for screen readers --}}

--- a/partials/post-filter-list.hbs
+++ b/partials/post-filter-list.hbs
@@ -63,9 +63,12 @@
     {{!-- Server-rendered post grid. NO x-cloak: JS-disabled users still see all posts. --}}
     <div class="post-feed container grid grid-cols-1 lg:grid-cols-3 gap-x-20 gap-y-10 m-auto">
         <!-- djlint:off -->
-        {{#get "posts" limit="1000" filter=filter include="tags" order="published_at desc" as |posts|}}
+        {{#get "posts" limit="all" filter=filter include="tags" order="published_at desc" as |posts|}}
         <!-- djlint:on -->
             {{#foreach posts}}
+                {{!-- isVisible() requires the [data-tags] node (the <article> in post-card.hbs).
+                     The wrapper div exists only as the x-show host so we don't toggle attributes
+                     on the article itself. --}}
                 <div x-show="isVisible($el.querySelector('[data-tags]'))" class="filter-card-wrapper">
                     {{> "post-card"}}
                 </div>
@@ -83,7 +86,3 @@
         </button>
     </div>
 </div>
-
-<style>
-    [x-cloak] { display: none !important; }
-</style>

--- a/partials/post-filter-list.hbs
+++ b/partials/post-filter-list.hbs
@@ -8,10 +8,28 @@
     id="post-filter-{{collection}}"
     x-data="postFilterList({ collection: '{{collection}}', mode: '{{mode}}', tagSlugs: '{{tagSlugs}}' })"
     class="post-filter-list">
-    {{!-- Toolbar: sort dropdown (and search input — added in Task 8). --}}
+    {{!-- Toolbar: search input (left, flex-1) + sort dropdown (right). --}}
     <div
         x-cloak
-        class="post-filter-toolbar container m-auto px-4 mb-6 flex flex-wrap gap-3 items-center justify-end">
+        class="post-filter-toolbar container m-auto px-4 mb-6 flex flex-wrap gap-3 items-center">
+        <div class="flex-1 min-w-[200px] flex items-center gap-2">
+            <label for="post-search-{{collection}}" class="sr-only">Search posts</label>
+            <input
+                id="post-search-{{collection}}"
+                type="search"
+                placeholder="Search posts..."
+                :value="searchQuery"
+                @input="setSearchQuery($event.target.value)"
+                @keydown.escape="setSearchQuery(''); $event.target.focus()"
+                aria-controls="post-grid-{{collection}}"
+                class="flex-1 px-3 py-2 rounded border border-gray-300 text-base">
+            <span
+                x-show="isSearching"
+                aria-live="polite"
+                class="text-base text-gray-600 whitespace-nowrap">
+                Searching…
+            </span>
+        </div>
         <div class="flex items-center gap-2">
             <label for="post-sort-{{collection}}" class="text-base text-gray-700">Sort:</label>
             <select
@@ -24,6 +42,15 @@
                 <option value="za">Title Z → A</option>
             </select>
         </div>
+    </div>
+
+    {{!-- Search error banner --}}
+    <div
+        x-cloak
+        x-show="searchError"
+        role="alert"
+        class="container m-auto px-4 mb-4 p-3 rounded border bg-red-50 border-red-200 text-red-900 text-base">
+        Search temporarily unavailable. Filters and sorting still work.
     </div>
 
     {{!-- Filter chips: hidden until Alpine init via x-cloak --}}
@@ -48,7 +75,7 @@
         <button
             type="button"
             @click="clearFilters()"
-            x-show="selectedTags.length > 0"
+            x-show="selectedTags.length > 0 || searchQuery.trim().length > 0 || sortMode !== 'newest'"
             class="px-4 py-2 rounded-full text-base text-gray-700 underline hover:text-gray-900">
             Clear filters
         </button>
@@ -75,11 +102,14 @@
         x-cloak
         x-show="filtered().length === 0"
         class="container m-auto px-4 py-12 text-center text-xl text-gray-700">
-        <p>No posts match your selected tags.</p>
+        <p x-show="searchQuery.trim().length > 0 && selectedTags.length > 0">No posts match your search and filters.</p>
+        <p x-show="searchQuery.trim().length > 0 && selectedTags.length === 0">No posts match your search.</p>
+        <p x-show="searchQuery.trim().length === 0 && selectedTags.length > 0">No posts match your selected tags.</p>
+        <p x-show="searchQuery.trim().length === 0 && selectedTags.length === 0">No posts to show.</p>
         <button
             type="button"
             @click="clearFilters()"
-            x-show="selectedTags.length > 0"
+            x-show="selectedTags.length > 0 || searchQuery.trim().length > 0 || sortMode !== 'newest'"
             class="mt-4 px-4 py-2 rounded-full border border-gray-900 text-base hover:bg-gray-900 hover:text-white transition-colors">
             Clear filters
         </button>

--- a/partials/post-filter-list.hbs
+++ b/partials/post-filter-list.hbs
@@ -11,7 +11,7 @@
     {{!-- Toolbar: sort dropdown (and search input — added in Task 8). --}}
     <div
         x-cloak
-        class="post-filter-toolbar container m-auto px-4 mb-4 flex flex-wrap gap-3 items-center justify-end">
+        class="post-filter-toolbar container m-auto px-4 mb-6 flex flex-wrap gap-3 items-center justify-end">
         <div class="flex items-center gap-2">
             <label for="post-sort-{{collection}}" class="text-base text-gray-700">Sort:</label>
             <select

--- a/partials/post-filter-list.hbs
+++ b/partials/post-filter-list.hbs
@@ -1,0 +1,89 @@
+{{!-- Reusable filter UI + post grid + load-more.
+     Parameters:
+       collection — string label (used as DOM id namespace)
+       filter     — Ghost filter string passed to {{#get "posts"}}
+       mode       — "or" (default) or "and" --}}
+
+<div
+    id="post-filter-{{collection}}"
+    x-data="postFilterList({ collection: '{{collection}}', mode: '{{mode}}' })"
+    class="post-filter-list">
+
+    {{!-- Filter chips: hidden until Alpine init via x-cloak --}}
+    <div
+        x-cloak
+        class="filter-chips container m-auto flex flex-wrap gap-2 mb-6 px-4"
+        x-show="availableTags.length > 0">
+        <template x-for="tag in availableTags" :key="tag.slug">
+            <button
+                type="button"
+                role="checkbox"
+                :aria-checked="isSelected(tag.slug)"
+                @click="toggleTag(tag.slug)"
+                :class="isSelected(tag.slug)
+                    ? 'bg-brand-light text-gray-900 border-gray-900'
+                    : 'bg-white text-gray-700 border-gray-300'"
+                class="px-4 py-2 rounded-full border text-base hover:border-gray-900 transition-colors">
+                <span x-text="tag.name"></span>
+            </button>
+        </template>
+        <button
+            type="button"
+            @click="clearFilters()"
+            x-show="selectedTags.length > 0"
+            class="px-4 py-2 rounded-full text-base text-gray-700 underline hover:text-gray-900">
+            Clear filters
+        </button>
+    </div>
+
+    {{!-- Live result count for screen readers --}}
+    <div x-cloak role="status" aria-live="polite" class="container m-auto px-4 mb-4 text-lg text-gray-700">
+        <span x-text="`Showing ${visible().length} of ${filtered().length}`"></span>
+    </div>
+
+    {{!-- Unknown-tags banner --}}
+    <div
+        x-cloak
+        x-show="unknownTags().length > 0"
+        class="container m-auto px-4 mb-4 p-3 rounded border bg-amber-50 border-amber-200 text-amber-900 text-base">
+        The following tags don't exist on this page:
+        <template x-for="(slug, i) in unknownTags()" :key="slug">
+            <span><code x-text="slug"></code><span x-show="i < unknownTags().length - 1">, </span></span>
+        </template>
+    </div>
+
+    {{!-- Empty state --}}
+    <div
+        x-cloak
+        x-show="filtered().length === 0"
+        class="container m-auto px-4 py-12 text-center text-xl text-gray-700">
+        <p>No posts match your selected tags.</p>
+    </div>
+
+    {{!-- Server-rendered post grid. NO x-cloak: JS-disabled users still see all posts. --}}
+    <div class="post-feed container grid grid-cols-1 lg:grid-cols-3 gap-x-20 gap-y-10 m-auto">
+        <!-- djlint:off -->
+        {{#get "posts" limit="1000" filter=filter include="tags" order="published_at desc" as |posts|}}
+        <!-- djlint:on -->
+            {{#foreach posts}}
+                <div x-show="isVisible($el.querySelector('[data-tags]'))" class="filter-card-wrapper">
+                    {{> "post-card"}}
+                </div>
+            {{/foreach}}
+        {{/get}}
+    </div>
+
+    {{!-- Load more button --}}
+    <div x-cloak class="container m-auto px-4 my-8 text-center" x-show="hasMore()">
+        <button
+            type="button"
+            @click="loadMore()"
+            class="px-6 py-3 rounded-full border border-gray-900 text-lg font-bold hover:bg-gray-900 hover:text-white transition-colors">
+            Load more
+        </button>
+    </div>
+</div>
+
+<style>
+    [x-cloak] { display: none !important; }
+</style>

--- a/partials/post-filter-list.hbs
+++ b/partials/post-filter-list.hbs
@@ -8,6 +8,23 @@
     id="post-filter-{{collection}}"
     x-data="postFilterList({ collection: '{{collection}}', mode: '{{mode}}' })"
     class="post-filter-list">
+    {{!-- Toolbar: sort dropdown (and search input — added in Task 8). --}}
+    <div
+        x-cloak
+        class="post-filter-toolbar container m-auto px-4 mb-4 flex flex-wrap gap-3 items-center justify-end">
+        <div class="flex items-center gap-2">
+            <label for="post-sort-{{collection}}" class="text-base text-gray-700">Sort:</label>
+            <select
+                id="post-sort-{{collection}}"
+                x-model="sortMode"
+                class="px-3 py-2 rounded border border-gray-300 text-base">
+                <option value="newest">Newest first</option>
+                <option value="oldest">Oldest first</option>
+                <option value="az">Title A → Z</option>
+                <option value="za">Title Z → A</option>
+            </select>
+        </div>
+    </div>
 
     {{!-- Filter chips: hidden until Alpine init via x-cloak --}}
     <div

--- a/partials/post-filter-list.hbs
+++ b/partials/post-filter-list.hbs
@@ -23,7 +23,8 @@
                 :class="isSelected(tag.slug)
                     ? 'bg-brand-light text-gray-900 border-gray-900'
                     : 'bg-white text-gray-700 border-gray-300'"
-                class="px-4 py-2 rounded-full border text-base hover:border-gray-900 transition-colors">
+                class="px-4 py-2 rounded-full border text-base hover:border-gray-900 transition-colors inline-flex items-center gap-1">
+                <span x-show="isSelected(tag.slug)" aria-hidden="true">✓</span>
                 <span x-text="tag.name"></span>
             </button>
         </template>
@@ -58,6 +59,13 @@
         x-show="filtered().length === 0"
         class="container m-auto px-4 py-12 text-center text-xl text-gray-700">
         <p>No posts match your selected tags.</p>
+        <button
+            type="button"
+            @click="clearFilters()"
+            x-show="selectedTags.length > 0"
+            class="mt-4 px-4 py-2 rounded-full border border-gray-900 text-base hover:bg-gray-900 hover:text-white transition-colors">
+            Clear filters
+        </button>
     </div>
 
     {{!-- Server-rendered post grid. NO x-cloak: JS-disabled users still see all posts. --}}
@@ -66,10 +74,12 @@
         {{#get "posts" limit="all" filter=filter include="tags" order="published_at desc" as |posts|}}
         <!-- djlint:on -->
             {{#foreach posts}}
-                {{!-- isVisible() requires the [data-tags] node (the <article> in post-card.hbs).
-                     The wrapper div exists only as the x-show host so we don't toggle attributes
-                     on the article itself. --}}
-                <div x-show="isVisible($el.querySelector('[data-tags]'))" class="filter-card-wrapper">
+                {{!-- The wrapper is the filter unit: tagged via its [data-tags] child,
+                     focusable for keyboard users via tabindex="-1", and reactive via x-show. --}}
+                <div
+                    x-show="isVisible($el)"
+                    tabindex="-1"
+                    class="filter-card-wrapper">
                     {{> "post-card"}}
                 </div>
             {{/foreach}}

--- a/partials/post-filter-list.hbs
+++ b/partials/post-filter-list.hbs
@@ -77,7 +77,7 @@
         <button
             type="button"
             @click="clearFilters()"
-            x-show="selectedTags.length > 0 || searchQuery.trim().length > 0 || sortMode !== 'newest'"
+            x-show="hasActiveFilters()"
             class="px-4 py-2 rounded-full text-base text-gray-700 underline hover:text-gray-900">
             Clear filters
         </button>
@@ -111,7 +111,7 @@
         <button
             type="button"
             @click="clearFilters()"
-            x-show="selectedTags.length > 0 || searchQuery.trim().length > 0 || sortMode !== 'newest'"
+            x-show="hasActiveFilters()"
             class="mt-4 px-4 py-2 rounded-full border border-gray-900 text-base hover:bg-gray-900 hover:text-white transition-colors">
             Clear filters
         </button>

--- a/partials/post-filter-list.hbs
+++ b/partials/post-filter-list.hbs
@@ -68,22 +68,30 @@
         </button>
     </div>
 
-    {{!-- Server-rendered post grid. NO x-cloak: JS-disabled users still see all posts. --}}
-    <div class="post-feed container grid grid-cols-1 lg:grid-cols-3 gap-x-20 gap-y-10 m-auto">
-        <!-- djlint:off -->
-        {{#get "posts" limit="all" filter=filter include="tags" order="published_at desc" as |posts|}}
-        <!-- djlint:on -->
-            {{#foreach posts}}
-                {{!-- The wrapper is the filter unit: tagged via its [data-tags] child,
-                     focusable for keyboard users via tabindex="-1", and reactive via x-show. --}}
-                <div
-                    x-show="isVisible($el)"
-                    tabindex="-1"
-                    class="filter-card-wrapper">
-                    {{> "post-card"}}
-                </div>
-            {{/foreach}}
-        {{/get}}
+    {{!-- Server-rendered post grid. 20 stacked page blocks (limit=100 each) work
+         around Ghost's silent 100-post cap on limit="all". Hard ceiling: 2000 posts.
+         NO x-cloak: JS-disabled users still see all posts. --}}
+    <div id="post-grid-{{collection}}" class="post-feed container grid grid-cols-1 lg:grid-cols-3 gap-x-20 gap-y-10 m-auto">
+        {{> "post-filter-page" page="1" filter=filter}}
+        {{> "post-filter-page" page="2" filter=filter}}
+        {{> "post-filter-page" page="3" filter=filter}}
+        {{> "post-filter-page" page="4" filter=filter}}
+        {{> "post-filter-page" page="5" filter=filter}}
+        {{> "post-filter-page" page="6" filter=filter}}
+        {{> "post-filter-page" page="7" filter=filter}}
+        {{> "post-filter-page" page="8" filter=filter}}
+        {{> "post-filter-page" page="9" filter=filter}}
+        {{> "post-filter-page" page="10" filter=filter}}
+        {{> "post-filter-page" page="11" filter=filter}}
+        {{> "post-filter-page" page="12" filter=filter}}
+        {{> "post-filter-page" page="13" filter=filter}}
+        {{> "post-filter-page" page="14" filter=filter}}
+        {{> "post-filter-page" page="15" filter=filter}}
+        {{> "post-filter-page" page="16" filter=filter}}
+        {{> "post-filter-page" page="17" filter=filter}}
+        {{> "post-filter-page" page="18" filter=filter}}
+        {{> "post-filter-page" page="19" filter=filter}}
+        {{> "post-filter-page" page="20" filter=filter}}
     </div>
 
     {{!-- Load more button --}}

--- a/partials/post-filter-list.hbs
+++ b/partials/post-filter-list.hbs
@@ -6,7 +6,7 @@
 
 <div
     id="post-filter-{{collection}}"
-    x-data="postFilterList({ collection: '{{collection}}', mode: '{{mode}}' })"
+    x-data="postFilterList({ collection: '{{collection}}', mode: '{{mode}}', tagSlugs: '{{tagSlugs}}' })"
     class="post-filter-list">
     {{!-- Toolbar: sort dropdown (and search input — added in Task 8). --}}
     <div

--- a/partials/post-filter-page.hbs
+++ b/partials/post-filter-page.hbs
@@ -1,0 +1,18 @@
+{{!-- Renders one page (up to 100 posts) for post-filter-list.hbs.
+     Receives:
+       page    — string "1".."20" (Ghost's {{#get}} accepts string page arg)
+       filter  — Ghost filter expression (same one used on every page block)
+     Cards are wrapped in .filter-card-wrapper so the parent Alpine component
+     can show/hide them via x-show. --}}
+<!-- djlint:off -->
+{{#get "posts" limit="100" page=page filter=filter include="tags" order="published_at desc" as |posts|}}
+<!-- djlint:on -->
+    {{#foreach posts}}
+        <div
+            x-show="isVisible($el)"
+            tabindex="-1"
+            class="filter-card-wrapper">
+            {{> "post-card"}}
+        </div>
+    {{/foreach}}
+{{/get}}

--- a/partials/post-filter-page.hbs
+++ b/partials/post-filter-page.hbs
@@ -3,8 +3,11 @@
        page    — string "1".."20" (Ghost's {{#get}} accepts string page arg)
        filter  — Ghost filter expression (same one used on every page block)
      Cards are wrapped in .filter-card-wrapper so the parent Alpine component
-     can show/hide them via x-show. --}}
+     can show/hide them via x-show. The wrapper carries tabindex="-1" so
+     loadMore() in post-filter-list.js can programmatically focus the first
+     newly-revealed card for keyboard users. --}}
 <!-- djlint:off -->
+{{!-- limit=100 is Ghost's per-page max for {{#get}}. --}}
 {{#get "posts" limit="100" page=page filter=filter include="tags" order="published_at desc" as |posts|}}
 <!-- djlint:on -->
     {{#foreach posts}}


### PR DESCRIPTION
Captures the brainstorming output for two features (overview index) and
the full design spec for Feature 1 — multi-tag client-side filtering on
the /events/ and /interviews/ collections, with URL sync and
load-more pagination.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<img width="1689" height="1330" alt="image" src="https://github.com/user-attachments/assets/63bffb72-35e1-4892-af30-fdfe68c97839" />
